### PR TITLE
feat: fleet pkg management + OS 26.04 release-upgrade (gtr-153 validated)

### DIFF
--- a/backends/ubuntu/compile.nix
+++ b/backends/ubuntu/compile.nix
@@ -147,6 +147,12 @@ let
   # Generate health checks JSON
   healthChecksData = builtins.toJSON cfg.healthChecks;
 
+  # Declarative apt package state (Ubuntu native packages)
+  aptData = builtins.toJSON {
+    inherit (cfg.apt) packages absent hold;
+  };
+  aptManaged = cfg.apt.packages != [ ] || cfg.apt.absent != [ ] || cfg.apt.hold != [ ];
+
   # Generate secrets payload (encrypted .age files)
   secretsPayload = pkgs.runCommand "nixfleet-secrets" { } ''
     mkdir -p $out
@@ -503,6 +509,9 @@ let
       mode = secretCfg.mode;
     }) cfg.secrets.items;
     secretsMode = cfg.secrets.mode;
+    apt = {
+      inherit (cfg.apt) packages absent hold;
+    };
   };
 
   manifestHash = builtins.hashString "sha256" manifestInputs;
@@ -796,6 +805,45 @@ let
       done
     fi
 
+    # Step 9b: Reconcile declarative apt packages
+    #
+    # Drift-only: we never run a blanket upgrade here (that's `nixfleet
+    # os-update`). We only act when a declared package is missing, present but
+    # should be absent, or not yet held. Holds are applied first so any install
+    # that follows respects them.
+    ${optionalString aptManaged ''
+      log "Reconciling declarative apt packages..."
+      export DEBIAN_FRONTEND=noninteractive
+
+      ${concatMapStringsSep "\n" (p: ''
+        if ! apt-mark showhold 2>/dev/null | grep -qx "${p}"; then
+          log "  Holding apt package: ${p}"
+          apt-mark hold "${p}" >/dev/null 2>&1 || log "    Warning: failed to hold ${p}"
+        fi
+      '') cfg.apt.hold}
+
+      APT_MISSING=""
+      ${concatMapStringsSep "\n" (p: ''
+        if ! dpkg -s "${p}" 2>/dev/null | grep -q "^Status: install ok installed"; then
+          APT_MISSING="$APT_MISSING ${p}"
+        fi
+      '') cfg.apt.packages}
+      if [ -n "$APT_MISSING" ]; then
+        log "  Installing missing apt packages:$APT_MISSING"
+        apt-get update -qq 2>/dev/null || log "    Warning: apt-get update failed; trying cached lists"
+        # shellcheck disable=SC2086
+        apt-get install -y --no-install-recommends $APT_MISSING \
+          || log "    Warning: apt-get install failed for:$APT_MISSING"
+      fi
+
+      ${concatMapStringsSep "\n" (p: ''
+        if dpkg -s "${p}" 2>/dev/null | grep -q "^Status: install ok installed"; then
+          log "  Removing apt package: ${p}"
+          apt-get remove -y "${p}" || log "    Warning: apt-get remove failed for ${p}"
+        fi
+      '') cfg.apt.absent}
+    ''}
+
     # Step 10: Install/update pull mode (if enabled)
     ${optionalString pullModeEnabled ''
       log "Installing pull mode..."
@@ -943,6 +991,7 @@ in
           echo '${directoriesData}' > $out/directories.json
           echo '${healthChecksData}' > $out/health-checks.json
           echo '${secretsMetadata}' > $out/secrets.json
+          echo '${aptData}' > $out/apt.json
           echo '${manifestHash}' > $out/manifest-hash
 
           # Create bin symlinks for convenience

--- a/cmd/nixfleet/internal/nix/evaluator.go
+++ b/cmd/nixfleet/internal/nix/evaluator.go
@@ -257,6 +257,27 @@ func (e *Evaluator) FlakePath() string {
 	return e.flakePath
 }
 
+// FlakeUpdate runs `nix flake update [inputs...]` against the flake, refreshing
+// flake.lock. With no inputs it updates every input; otherwise only the named
+// ones (e.g. "nixpkgs"). Returns the combined nix output, which on a real
+// change includes the "Updated input ...: 'old' → 'new'" lines.
+func (e *Evaluator) FlakeUpdate(ctx context.Context, inputs ...string) (string, error) {
+	args := []string{"flake", "update"}
+	args = append(args, inputs...)
+	// nix flake update operates on the flake in the current dir; point it at ours.
+	cmd := exec.CommandContext(ctx, e.nixBin, args...)
+	cmd.Dir = e.flakePath
+
+	var combined bytes.Buffer
+	cmd.Stdout = &combined
+	cmd.Stderr = &combined
+
+	if err := cmd.Run(); err != nil {
+		return combined.String(), fmt.Errorf("nix flake update failed: %w", err)
+	}
+	return combined.String(), nil
+}
+
 // ResolveFlakePath resolves a potentially relative flake path
 func ResolveFlakePath(path string) (string, error) {
 	if filepath.IsAbs(path) {

--- a/cmd/nixfleet/internal/osupdate/release.go
+++ b/cmd/nixfleet/internal/osupdate/release.go
@@ -28,6 +28,7 @@ type ReleaseInfo struct {
 	RunningEOL     bool
 	ToolAvailable  bool  // do-release-upgrade present
 	FreeRootMB     int64 // free space on / in MiB
+	FreeBootMB     int64 // free space on /boot in MiB (often a small separate partition)
 	RebootRequired bool
 }
 
@@ -47,6 +48,9 @@ type ReleaseUpgradeConfig struct {
 	PostHook string
 	// MinFreeRootMB aborts the upgrade if / has less free space than this.
 	MinFreeRootMB int64
+	// MinFreeBootMB aborts the upgrade if /boot has less free space than this.
+	// A new kernel + (MODULES=most) initramfs needs ~200-350 MiB of /boot.
+	MinFreeBootMB int64
 	// LogPath is the host-side log for the detached upgrade.
 	LogPath string
 	// Unit is the transient systemd unit name the upgrade runs under.
@@ -57,6 +61,7 @@ type ReleaseUpgradeConfig struct {
 func DefaultReleaseUpgradeConfig() ReleaseUpgradeConfig {
 	return ReleaseUpgradeConfig{
 		MinFreeRootMB: 8192, // ~8 GiB headroom for downloaded+unpacked packages
+		MinFreeBootMB: 350,  // one new kernel + initramfs (MODULES=most) + headroom
 		LogPath:       "/var/log/nixfleet/release-upgrade.log",
 		Unit:          "nixfleet-release-upgrade",
 	}
@@ -97,6 +102,12 @@ func (u *Updater) CheckReleaseInfo(ctx context.Context, client *ssh.Client) (*Re
 	if df, err := client.Exec(ctx, "df -Pm / | awk 'NR==2{print $4}'"); err == nil {
 		info.FreeRootMB, _ = strconv.ParseInt(strings.TrimSpace(df.Stdout), 10, 64)
 	}
+	// /boot is frequently a small dedicated partition (or a ZFS bpool); a release
+	// upgrade installs a new kernel + initramfs there, so it must be checked
+	// separately from /. A too-small /boot is a classic upgrade-blocker.
+	if df, err := client.Exec(ctx, "df -Pm /boot | awk 'NR==2{print $4}'"); err == nil {
+		info.FreeBootMB, _ = strconv.ParseInt(strings.TrimSpace(df.Stdout), 10, 64)
+	}
 	info.RebootRequired, _ = u.IsRebootRequired(ctx, client)
 
 	return info, nil
@@ -135,6 +146,9 @@ func (u *Updater) PrepareRelease(ctx context.Context, client *ssh.Client) error 
 func (u *Updater) StartReleaseUpgrade(ctx context.Context, client *ssh.Client, info *ReleaseInfo, cfg ReleaseUpgradeConfig) error {
 	if cfg.MinFreeRootMB > 0 && info.FreeRootMB > 0 && info.FreeRootMB < cfg.MinFreeRootMB {
 		return fmt.Errorf("insufficient free space on /: %d MiB < required %d MiB", info.FreeRootMB, cfg.MinFreeRootMB)
+	}
+	if cfg.MinFreeBootMB > 0 && info.FreeBootMB > 0 && info.FreeBootMB < cfg.MinFreeBootMB {
+		return fmt.Errorf("insufficient free space on /boot: %d MiB < required %d MiB (remove old kernels or slim the initramfs)", info.FreeBootMB, cfg.MinFreeBootMB)
 	}
 
 	if cfg.PreHook != "" {

--- a/cmd/nixfleet/internal/osupdate/release.go
+++ b/cmd/nixfleet/internal/osupdate/release.go
@@ -1,0 +1,266 @@
+package osupdate
+
+import (
+	"context"
+	"fmt"
+	"regexp"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/nixfleet/nixfleet/internal/ssh"
+)
+
+// ReleaseInfo describes a host's distro release and the available upgrade.
+type ReleaseInfo struct {
+	CurrentVersion string // e.g. "25.10"
+	Codename       string // e.g. "questing"
+	TargetRelease  string // e.g. "26.04 LTS", "" if none offered
+	// Supported means do-release-upgrade offers an upgrade target. This can be
+	// true even when the *running* release is past EOL: Ubuntu still advertises
+	// the next interim release (e.g. EOL 25.04 → 25.10), and do-release-upgrade
+	// handles that hop normally. Only a stranded host (RunningEOL && no target)
+	// needs the apt-sources codename-rewrite fallback.
+	Supported bool
+	// RunningEOL is true when the currently-installed release is itself past EOL
+	// ("not supported anymore"). Informational; does not by itself block the
+	// supported do-release-upgrade path.
+	RunningEOL     bool
+	ToolAvailable  bool  // do-release-upgrade present
+	FreeRootMB     int64 // free space on / in MiB
+	RebootRequired bool
+}
+
+// ReleaseUpgradeConfig controls a single host's release upgrade.
+type ReleaseUpgradeConfig struct {
+	// AllowEOL permits upgrading a host whose current release is EOL. Such hosts
+	// cannot use do-release-upgrade; NextCodename must also be set so we can do a
+	// sources-list codename rewrite + full-upgrade instead.
+	AllowEOL bool
+	// NextCodename is the codename of the next release to step an EOL host to
+	// (e.g. "questing"). Only used on the EOL path. We never guess it.
+	NextCodename string
+	// PreHook runs (sudo) before the upgrade — e.g. cordon/drain k0s, stop
+	// inference units. A non-zero exit aborts the upgrade.
+	PreHook string
+	// PostHook runs (sudo) after the host is verified back up — e.g. uncordon.
+	PostHook string
+	// MinFreeRootMB aborts the upgrade if / has less free space than this.
+	MinFreeRootMB int64
+	// LogPath is the host-side log for the detached upgrade.
+	LogPath string
+	// Unit is the transient systemd unit name the upgrade runs under.
+	Unit string
+}
+
+// DefaultReleaseUpgradeConfig returns sane defaults.
+func DefaultReleaseUpgradeConfig() ReleaseUpgradeConfig {
+	return ReleaseUpgradeConfig{
+		MinFreeRootMB: 8192, // ~8 GiB headroom for downloaded+unpacked packages
+		LogPath:       "/var/log/nixfleet/release-upgrade.log",
+		Unit:          "nixfleet-release-upgrade",
+	}
+}
+
+// CheckReleaseInfo gathers the host's release + upgrade availability. Read-only.
+func (u *Updater) CheckReleaseInfo(ctx context.Context, client *ssh.Client) (*ReleaseInfo, error) {
+	info := &ReleaseInfo{}
+
+	osRel, err := client.Exec(ctx, ". /etc/os-release && echo \"$VERSION_ID|$VERSION_CODENAME\"")
+	if err != nil {
+		return nil, fmt.Errorf("reading /etc/os-release: %w", err)
+	}
+	parts := strings.SplitN(strings.TrimSpace(osRel.Stdout), "|", 2)
+	if len(parts) == 2 {
+		info.CurrentVersion = parts[0]
+		info.Codename = parts[1]
+	}
+
+	// do-release-upgrade -c: prints "New release 'X' available" or, for EOL,
+	// "Your Ubuntu release is not supported anymore".
+	if tool, _ := client.Exec(ctx, "command -v do-release-upgrade >/dev/null 2>&1 && echo yes || echo no"); tool != nil {
+		info.ToolAvailable = strings.TrimSpace(tool.Stdout) == "yes"
+	}
+	if info.ToolAvailable {
+		check, _ := client.Exec(ctx, "do-release-upgrade -c 2>&1 || true")
+		out := check.Stdout
+		// A target may be advertised even alongside an EOL notice, so detect both
+		// independently. Supported == "a target is offered" (do-release-upgrade can
+		// proceed); RunningEOL is purely informational.
+		if m := regexp.MustCompile(`New release '([^']+)' available`).FindStringSubmatch(out); m != nil {
+			info.TargetRelease = m[1]
+		}
+		info.RunningEOL = strings.Contains(out, "not supported anymore")
+		info.Supported = info.TargetRelease != ""
+	}
+
+	if df, err := client.Exec(ctx, "df -Pm / | awk 'NR==2{print $4}'"); err == nil {
+		info.FreeRootMB, _ = strconv.ParseInt(strings.TrimSpace(df.Stdout), 10, 64)
+	}
+	info.RebootRequired, _ = u.IsRebootRequired(ctx, client)
+
+	return info, nil
+}
+
+// PrepareRelease readies a host for upgrade: sets the upgrade prompt to normal
+// and fully patches the current release first (a clean within-release state is a
+// precondition for a reliable release upgrade).
+func (u *Updater) PrepareRelease(ctx context.Context, client *ssh.Client) error {
+	// Prompt=normal so do-release-upgrade offers the next interim/LTS.
+	if _, err := client.ExecSudo(ctx, "sed -i 's/^Prompt=.*/Prompt=normal/' /etc/update-manager/release-upgrades"); err != nil {
+		return fmt.Errorf("setting release-upgrade prompt: %w", err)
+	}
+	if err := u.RefreshPackageCache(ctx, client); err != nil {
+		return err
+	}
+	cmd := "DEBIAN_FRONTEND=noninteractive apt-get -y -o Dpkg::Options::='--force-confdef' -o Dpkg::Options::='--force-confold' full-upgrade"
+	res, err := client.ExecSudo(ctx, cmd)
+	if err != nil {
+		return fmt.Errorf("pre-upgrade full-upgrade: %w", err)
+	}
+	if res.ExitCode != 0 {
+		return fmt.Errorf("pre-upgrade full-upgrade failed: %s", res.Stderr)
+	}
+	return nil
+}
+
+// StartReleaseUpgrade launches the release upgrade detached under a transient
+// systemd unit so it survives SSH disconnects. Returns once the unit is started.
+// Use ReleaseUpgradeStatus to poll for completion.
+//
+// Supported releases use do-release-upgrade in its non-interactive server
+// frontend. EOL releases (which do-release-upgrade refuses) instead get a
+// codename rewrite of the apt sources + full-upgrade, gated behind AllowEOL +
+// NextCodename so it is always an explicit operator choice.
+func (u *Updater) StartReleaseUpgrade(ctx context.Context, client *ssh.Client, info *ReleaseInfo, cfg ReleaseUpgradeConfig) error {
+	if cfg.MinFreeRootMB > 0 && info.FreeRootMB > 0 && info.FreeRootMB < cfg.MinFreeRootMB {
+		return fmt.Errorf("insufficient free space on /: %d MiB < required %d MiB", info.FreeRootMB, cfg.MinFreeRootMB)
+	}
+
+	if cfg.PreHook != "" {
+		res, err := client.ExecSudo(ctx, cfg.PreHook)
+		if err != nil {
+			return fmt.Errorf("pre-upgrade hook failed: %w", err)
+		}
+		if res.ExitCode != 0 {
+			return fmt.Errorf("pre-upgrade hook failed (exit %d): %s", res.ExitCode, res.Stderr)
+		}
+	}
+
+	var upgradeCmd string
+	switch {
+	case info.TargetRelease != "":
+		// do-release-upgrade advertises a target — use it even from an EOL release.
+		upgradeCmd = "DEBIAN_FRONTEND=noninteractive do-release-upgrade -f DistUpgradeViewNonInteractive -m server"
+	case cfg.AllowEOL && info.RunningEOL:
+		// Stranded EOL host: no target offered. Fall back to a sources codename
+		// rewrite + full-upgrade.
+		if cfg.NextCodename == "" {
+			return fmt.Errorf("host is EOL and requires --next-codename to rewrite apt sources (do-release-upgrade cannot upgrade an EOL release)")
+		}
+		if info.Codename == "" {
+			return fmt.Errorf("could not determine current codename for EOL sources rewrite")
+		}
+		// Rewrite every occurrence of the current codename to the next across the
+		// apt source definitions (handles both classic .list and deb822 .sources),
+		// then do a full-upgrade onto the new release.
+		from, to := info.Codename, cfg.NextCodename
+		upgradeCmd = fmt.Sprintf(
+			"set -e; "+
+				"find /etc/apt/sources.list /etc/apt/sources.list.d/ -type f \\( -name '*.list' -o -name '*.sources' \\) "+
+				"-exec sed -i 's/%s/%s/g' {} + ; "+
+				"DEBIAN_FRONTEND=noninteractive apt-get update; "+
+				"DEBIAN_FRONTEND=noninteractive apt-get -y -o Dpkg::Options::='--force-confdef' -o Dpkg::Options::='--force-confold' full-upgrade",
+			from, to)
+	case info.RunningEOL:
+		return fmt.Errorf("host release %q is EOL with no upgrade target offered; pass --allow-eol with --next-codename to rewrite apt sources", info.CurrentVersion)
+	default:
+		return fmt.Errorf("no upgrade target available for host release %q", info.CurrentVersion)
+	}
+
+	// Detach via systemd-run so the long upgrade outlives our SSH session, with
+	// all output captured to LogPath for polling/forensics.
+	logDir := cfg.LogPath[:strings.LastIndex(cfg.LogPath, "/")]
+	launch := fmt.Sprintf(
+		"mkdir -p %s && systemd-run --unit=%s --collect --setenv=DEBIAN_FRONTEND=noninteractive "+
+			"/bin/bash -c %s",
+		shQuote(logDir), shQuote(cfg.Unit),
+		shQuote(fmt.Sprintf("{ %s ; } > %s 2>&1", upgradeCmd, cfg.LogPath)),
+	)
+	res, err := client.ExecSudo(ctx, launch)
+	if err != nil {
+		return fmt.Errorf("launching detached upgrade: %w", err)
+	}
+	if res.ExitCode != 0 {
+		return fmt.Errorf("launching detached upgrade failed: %s", res.Stderr)
+	}
+	return nil
+}
+
+// ReleaseUpgradeStatus polls the detached upgrade. running is true while the
+// transient unit is active; when it stops, exitCode is its main process exit
+// status (0 = success). tail is the last few log lines for progress display.
+func (u *Updater) ReleaseUpgradeStatus(ctx context.Context, client *ssh.Client, cfg ReleaseUpgradeConfig) (running bool, exitCode int, tail string, err error) {
+	act, err := client.Exec(ctx, fmt.Sprintf("systemctl is-active %s 2>/dev/null || true", shQuote(cfg.Unit)))
+	if err != nil {
+		return false, -1, "", err
+	}
+	state := strings.TrimSpace(act.Stdout)
+	running = state == "active" || state == "activating" || state == "deactivating"
+
+	if t, e := client.Exec(ctx, fmt.Sprintf("tail -n 5 %s 2>/dev/null || true", shQuote(cfg.LogPath))); e == nil {
+		tail = strings.TrimRight(t.Stdout, "\n")
+	}
+
+	exitCode = -1
+	if !running {
+		if s, e := client.Exec(ctx, fmt.Sprintf("systemctl show %s -p ExecMainStatus --value 2>/dev/null || true", shQuote(cfg.Unit))); e == nil {
+			if v, perr := strconv.Atoi(strings.TrimSpace(s.Stdout)); perr == nil {
+				exitCode = v
+			}
+		}
+	}
+	return running, exitCode, tail, nil
+}
+
+// WaitForReleaseUpgrade blocks until the detached upgrade finishes or ctx/deadline
+// expires, invoking onProgress with each polled log tail.
+func (u *Updater) WaitForReleaseUpgrade(ctx context.Context, client *ssh.Client, cfg ReleaseUpgradeConfig, poll time.Duration, onProgress func(tail string)) (int, error) {
+	if poll <= 0 {
+		poll = 30 * time.Second
+	}
+	for {
+		select {
+		case <-ctx.Done():
+			return -1, ctx.Err()
+		default:
+		}
+		running, exit, tail, err := u.ReleaseUpgradeStatus(ctx, client, cfg)
+		if err != nil {
+			return -1, err
+		}
+		if onProgress != nil && tail != "" {
+			onProgress(tail)
+		}
+		if !running {
+			return exit, nil
+		}
+		time.Sleep(poll)
+	}
+}
+
+// VerifyRelease confirms the running release now matches wantVersion (a prefix
+// match, e.g. "26.04"). Returns the observed VERSION_ID.
+func (u *Updater) VerifyRelease(ctx context.Context, client *ssh.Client, wantVersion string) (bool, string, error) {
+	res, err := client.Exec(ctx, ". /etc/os-release && echo \"$VERSION_ID\"")
+	if err != nil {
+		return false, "", err
+	}
+	got := strings.TrimSpace(res.Stdout)
+	return strings.HasPrefix(got, wantVersion), got, nil
+}
+
+// shQuote single-quotes a string for safe embedding in a /bin/sh command.
+func shQuote(s string) string {
+	return "'" + strings.ReplaceAll(s, "'", `'\''`) + "'"
+}

--- a/cmd/nixfleet/internal/osupdate/release.go
+++ b/cmd/nixfleet/internal/osupdate/release.go
@@ -152,7 +152,10 @@ func (u *Updater) StartReleaseUpgrade(ctx context.Context, client *ssh.Client, i
 	}
 
 	if cfg.PreHook != "" {
-		res, err := client.ExecSudo(ctx, cfg.PreHook)
+		// bash -c wrap so a compound hook (e.g. "systemctl stop a b || true; drain")
+		// runs entirely as root, not just its first command (ExecSudo only sudo's
+		// the leading token).
+		res, err := client.ExecSudo(ctx, fmt.Sprintf("bash -c %s", shQuote(cfg.PreHook)))
 		if err != nil {
 			return fmt.Errorf("pre-upgrade hook failed: %w", err)
 		}
@@ -194,14 +197,19 @@ func (u *Updater) StartReleaseUpgrade(ctx context.Context, client *ssh.Client, i
 
 	// Detach via systemd-run so the long upgrade outlives our SSH session, with
 	// all output captured to LogPath for polling/forensics.
+	//
+	// The whole launch is wrapped in `bash -c` because ExecSudo only prepends a
+	// single `sudo` token: an unwrapped `mkdir && systemd-run` would run
+	// systemd-run unprivileged (polkit: "Interactive authentication required").
+	// `sudo bash -c '<all of it>'` runs every part as root.
 	logDir := cfg.LogPath[:strings.LastIndex(cfg.LogPath, "/")]
-	launch := fmt.Sprintf(
+	inner := fmt.Sprintf(
 		"mkdir -p %s && systemd-run --unit=%s --collect --setenv=DEBIAN_FRONTEND=noninteractive "+
 			"/bin/bash -c %s",
 		shQuote(logDir), shQuote(cfg.Unit),
 		shQuote(fmt.Sprintf("{ %s ; } > %s 2>&1", upgradeCmd, cfg.LogPath)),
 	)
-	res, err := client.ExecSudo(ctx, launch)
+	res, err := client.ExecSudo(ctx, fmt.Sprintf("bash -c %s", shQuote(inner)))
 	if err != nil {
 		return fmt.Errorf("launching detached upgrade: %w", err)
 	}

--- a/cmd/nixfleet/internal/osupdate/release.go
+++ b/cmd/nixfleet/internal/osupdate/release.go
@@ -168,7 +168,12 @@ func (u *Updater) StartReleaseUpgrade(ctx context.Context, client *ssh.Client, i
 	switch {
 	case info.TargetRelease != "":
 		// do-release-upgrade advertises a target — use it even from an EOL release.
-		upgradeCmd = "DEBIAN_FRONTEND=noninteractive do-release-upgrade -f DistUpgradeViewNonInteractive -m server"
+		// NB: no `-m/--mode server` flag — recent do-release-upgrade has no such
+		// option (it errors "no such option: -m"). The non-interactive frontend
+		// is sufficient. Third-party repos (e.g. the AMD ROCm apt source) are
+		// intentionally left to be auto-disabled (no --allow-third-party): they
+		// have no candidate for the new release and held packages stay installed.
+		upgradeCmd = "DEBIAN_FRONTEND=noninteractive do-release-upgrade -f DistUpgradeViewNonInteractive"
 	case cfg.AllowEOL && info.RunningEOL:
 		// Stranded EOL host: no target offered. Fall back to a sources codename
 		// rewrite + full-upgrade.
@@ -203,11 +208,20 @@ func (u *Updater) StartReleaseUpgrade(ctx context.Context, client *ssh.Client, i
 	// systemd-run unprivileged (polkit: "Interactive authentication required").
 	// `sudo bash -c '<all of it>'` runs every part as root.
 	logDir := cfg.LogPath[:strings.LastIndex(cfg.LogPath, "/")]
+	exitFile := cfg.LogPath + ".exit"
+	// The transient unit runs with --collect, so it is garbage-collected the
+	// instant it exits and `systemctl show -p ExecMainStatus` is then empty —
+	// reading it would falsely look like success. So the wrapper records the
+	// upgrade's real exit code to a sentinel file we can read after the unit is
+	// gone. The sentinel is removed up front so a stale value from a prior run
+	// can't be mistaken for this run's result.
+	runScript := fmt.Sprintf("rm -f %s; { %s ; } > %s 2>&1; echo $? > %s",
+		shQuote(exitFile), upgradeCmd, shQuote(cfg.LogPath), shQuote(exitFile))
 	inner := fmt.Sprintf(
-		"mkdir -p %s && systemd-run --unit=%s --collect --setenv=DEBIAN_FRONTEND=noninteractive "+
+		"mkdir -p %s && rm -f %s && systemd-run --unit=%s --collect --setenv=DEBIAN_FRONTEND=noninteractive "+
 			"/bin/bash -c %s",
-		shQuote(logDir), shQuote(cfg.Unit),
-		shQuote(fmt.Sprintf("{ %s ; } > %s 2>&1", upgradeCmd, cfg.LogPath)),
+		shQuote(logDir), shQuote(exitFile), shQuote(cfg.Unit),
+		shQuote(runScript),
 	)
 	res, err := client.ExecSudo(ctx, fmt.Sprintf("bash -c %s", shQuote(inner)))
 	if err != nil {
@@ -234,9 +248,14 @@ func (u *Updater) ReleaseUpgradeStatus(ctx context.Context, client *ssh.Client, 
 		tail = strings.TrimRight(t.Stdout, "\n")
 	}
 
+	// Read the exit code from the sentinel the wrapper writes (the --collect
+	// unit is gone by now, so ExecMainStatus is unreliable). Absent/unreadable
+	// sentinel → leave exitCode at -1, which callers treat as "not a success"
+	// (and therefore do NOT reboot) — failing safe.
 	exitCode = -1
 	if !running {
-		if s, e := client.Exec(ctx, fmt.Sprintf("systemctl show %s -p ExecMainStatus --value 2>/dev/null || true", shQuote(cfg.Unit))); e == nil {
+		exitFile := cfg.LogPath + ".exit"
+		if s, e := client.Exec(ctx, fmt.Sprintf("cat %s 2>/dev/null || true", shQuote(exitFile))); e == nil {
 			if v, perr := strconv.Atoi(strings.TrimSpace(s.Stdout)); perr == nil {
 				exitCode = v
 			}

--- a/cmd/nixfleet/internal/osupdate/release_test.go
+++ b/cmd/nixfleet/internal/osupdate/release_test.go
@@ -1,0 +1,33 @@
+package osupdate
+
+import "testing"
+
+func TestShQuote(t *testing.T) {
+	cases := []struct {
+		in   string
+		want string
+	}{
+		{"plain", "'plain'"},
+		{"with space", "'with space'"},
+		{"/var/log/nixfleet", "'/var/log/nixfleet'"},
+		// A value containing a single quote must be split-and-escaped so it can't
+		// break out of the surrounding quotes (shell-injection safety).
+		{"it's", `'it'\''s'`},
+		{"a'; rm -rf /; '", `'a'\''; rm -rf /; '\'''`},
+	}
+	for _, c := range cases {
+		if got := shQuote(c.in); got != c.want {
+			t.Errorf("shQuote(%q) = %q, want %q", c.in, got, c.want)
+		}
+	}
+}
+
+func TestDefaultReleaseUpgradeConfig(t *testing.T) {
+	c := DefaultReleaseUpgradeConfig()
+	if c.MinFreeRootMB <= 0 {
+		t.Errorf("expected positive MinFreeRootMB, got %d", c.MinFreeRootMB)
+	}
+	if c.LogPath == "" || c.Unit == "" {
+		t.Errorf("expected non-empty LogPath and Unit, got %q / %q", c.LogPath, c.Unit)
+	}
+}

--- a/cmd/nixfleet/main.go
+++ b/cmd/nixfleet/main.go
@@ -1247,6 +1247,32 @@ Always serial — one host at a time — to protect shared services.`,
 					continue
 				}
 
+				// do-release-upgrade refuses to run while a reboot is pending
+				// ("you have not rebooted after updating a package which requires
+				// a reboot"). The prepare full-upgrade can install a new kernel, so
+				// reboot into it first, then proceed. Also covers each hop of an
+				// EOL two-hop upgrade.
+				if rr, _ := updater.IsRebootRequired(ctx, client); rr {
+					fmt.Printf("  Reboot required after prepare (new kernel) — rebooting first...\n")
+					preRO := reboot.NewOrchestrator(func() reboot.RebootConfig {
+						c := reboot.DefaultRebootConfig()
+						c.AllowReboot = true
+						if waitTimeout > 0 {
+							c.WaitTimeout = waitTimeout
+						}
+						return c
+					}())
+					if err := preRO.ExecuteReboot(ctx, client, pool, host.Addr, host.SSHPort, host.SSHUser); err != nil {
+						fmt.Printf("  pre-upgrade reboot failed: %v\n\n", err)
+						continue
+					}
+					client, err = pool.GetWithUser(ctx, host.Addr, host.SSHPort, host.SSHUser)
+					if err != nil {
+						fmt.Printf("  reconnect after pre-upgrade reboot failed: %v\n\n", err)
+						continue
+					}
+				}
+
 				fmt.Printf("  Launching detached release upgrade...\n")
 				if err := updater.StartReleaseUpgrade(ctx, client, info, cfg); err != nil {
 					fmt.Printf("  launch failed: %v\n\n", err)

--- a/cmd/nixfleet/main.go
+++ b/cmd/nixfleet/main.go
@@ -9,6 +9,7 @@ import (
 	"os/exec"
 	"os/signal"
 	"path/filepath"
+	"regexp"
 	"runtime"
 	"strings"
 	"syscall"
@@ -663,6 +664,7 @@ Subcommands:
 	cmd.AddCommand(osUpdatePolicyCmd())
 	cmd.AddCommand(osUpdateHoldCmd())
 	cmd.AddCommand(osUpdateUnholdCmd())
+	cmd.AddCommand(osUpdateReleaseUpgradeCmd())
 
 	return cmd
 }
@@ -1079,6 +1081,235 @@ func osUpdateUnholdCmd() *cobra.Command {
 			return nil
 		},
 	}
+}
+
+func osUpdateReleaseUpgradeCmd() *cobra.Command {
+	var (
+		only         string
+		target       string
+		allowEOL     bool
+		nextCodename string
+		stopUnits    []string
+		preHook      string
+		postHook     string
+		noReboot     bool
+		assumeYes    bool
+		checkOnly    bool
+		pollEvery    time.Duration
+		waitTimeout  time.Duration
+	)
+
+	cmd := &cobra.Command{
+		Use:   "release-upgrade",
+		Short: "Upgrade Ubuntu hosts to a new distro release (e.g. 26.04 LTS)",
+		Long: `Orchestrate a serial, per-host Ubuntu release upgrade (do-release-upgrade).
+
+For each Ubuntu host, in turn:
+  1. check the available release + free disk
+  2. (unless --check) run pre-hook (stop --stop-units, drain, ...), fully patch
+     the current release, then launch the upgrade DETACHED under a transient
+     systemd unit (survives SSH drops) and stream progress
+  3. reboot and wait for the host to return
+  4. verify the new release and run the post-hook (uncordon, ...)
+
+EOL releases cannot use do-release-upgrade; pass --allow-eol together with
+--next-codename to instead rewrite the apt sources codename and full-upgrade.
+Always serial — one host at a time — to protect shared services.`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := cmd.Context()
+
+			_, hosts, err := loadInventoryAndHosts(ctx)
+			if err != nil {
+				return err
+			}
+			hosts = filterUbuntuHosts(hosts)
+			if only != "" {
+				var sel []*inventory.Host
+				for _, h := range hosts {
+					if h.Name == only {
+						sel = append(sel, h)
+					}
+				}
+				if len(sel) == 0 {
+					return fmt.Errorf("host %q not found among Ubuntu hosts", only)
+				}
+				hosts = sel
+			}
+			if len(hosts) == 0 {
+				fmt.Println("No Ubuntu hosts found")
+				return nil
+			}
+
+			pool := ssh.NewPool(nil)
+			defer pool.Close()
+			updater := osupdate.NewUpdater()
+
+			preHookFull := preHook
+			if len(stopUnits) > 0 {
+				stop := fmt.Sprintf("systemctl stop %s || true", strings.Join(stopUnits, " "))
+				if preHookFull != "" {
+					preHookFull = stop + "; " + preHookFull
+				} else {
+					preHookFull = stop
+				}
+			}
+
+			fmt.Printf("Release-upgrade plan for %d host(s) [serial]:\n\n", len(hosts))
+
+			for _, host := range hosts {
+				fmt.Printf("=== %s (%s) ===\n", host.Name, host.Addr)
+				client, err := pool.GetWithUser(ctx, host.Addr, host.SSHPort, host.SSHUser)
+				if err != nil {
+					fmt.Printf("  connection failed: %v\n\n", err)
+					continue
+				}
+
+				info, err := updater.CheckReleaseInfo(ctx, client)
+				if err != nil {
+					fmt.Printf("  check failed: %v\n\n", err)
+					continue
+				}
+				eolNote := ""
+				if info.RunningEOL {
+					eolNote = " [running release is EOL]"
+				}
+				fmt.Printf("  current: %s (%s)%s  free /: %d MiB  target: %q\n",
+					info.CurrentVersion, info.Codename, eolNote, info.FreeRootMB, info.TargetRelease)
+
+				if checkOnly {
+					fmt.Println()
+					continue
+				}
+
+				// Decision: a target from do-release-upgrade drives the supported
+				// path (works even from an EOL release). Only a stranded EOL host
+				// (no target) needs the --allow-eol codename-rewrite fallback.
+				if info.TargetRelease == "" {
+					if info.RunningEOL {
+						if !allowEOL || nextCodename == "" {
+							fmt.Printf("  SKIP: EOL with no upgrade target; pass --allow-eol --next-codename <name>\n\n")
+							continue
+						}
+					} else {
+						fmt.Printf("  SKIP: already on the latest available release\n\n")
+						continue
+					}
+				}
+
+				// Determine the version we expect to land on, for verification.
+				wantVer := target
+				if wantVer == "" {
+					if m := regexp.MustCompile(`(\d+\.\d+)`).FindStringSubmatch(info.TargetRelease); m != nil {
+						wantVer = m[1]
+					}
+				}
+
+				if !assumeYes {
+					dest := info.TargetRelease
+					if dest == "" && info.RunningEOL {
+						dest = "codename " + nextCodename + " (EOL sources rewrite)"
+					}
+					fmt.Printf("  Proceed with upgrade of %s → %s? [y/N]: ", host.Name, dest)
+					var resp string
+					fmt.Scanln(&resp)
+					if !strings.HasPrefix(strings.ToLower(strings.TrimSpace(resp)), "y") {
+						fmt.Printf("  skipped by operator\n\n")
+						continue
+					}
+				}
+
+				cfg := osupdate.DefaultReleaseUpgradeConfig()
+				cfg.AllowEOL = allowEOL
+				cfg.NextCodename = nextCodename
+				cfg.PreHook = preHookFull
+				cfg.PostHook = postHook
+
+				fmt.Printf("  Preparing (set prompt, full-upgrade current release)...\n")
+				if err := updater.PrepareRelease(ctx, client); err != nil {
+					fmt.Printf("  prepare failed: %v\n\n", err)
+					continue
+				}
+
+				fmt.Printf("  Launching detached release upgrade...\n")
+				if err := updater.StartReleaseUpgrade(ctx, client, info, cfg); err != nil {
+					fmt.Printf("  launch failed: %v\n\n", err)
+					continue
+				}
+
+				exit, err := updater.WaitForReleaseUpgrade(ctx, client, cfg, pollEvery, func(tail string) {
+					last := tail
+					if i := strings.LastIndex(tail, "\n"); i >= 0 {
+						last = tail[i+1:]
+					}
+					fmt.Printf("    … %s\n", last)
+				})
+				if err != nil {
+					fmt.Printf("  upgrade wait failed: %v (check %s on host)\n\n", err, cfg.LogPath)
+					continue
+				}
+				if exit != 0 {
+					fmt.Printf("  UPGRADE FAILED (exit %d) — host NOT rebooted. Inspect %s\n\n", exit, cfg.LogPath)
+					continue
+				}
+				fmt.Printf("  Upgrade process completed.\n")
+
+				if noReboot {
+					fmt.Printf("  --no-reboot set; reboot %s manually then verify.\n\n", host.Name)
+					continue
+				}
+
+				fmt.Printf("  Rebooting and waiting for host...\n")
+				rebootOrch := reboot.NewOrchestrator(func() reboot.RebootConfig {
+					c := reboot.DefaultRebootConfig()
+					c.AllowReboot = true
+					if waitTimeout > 0 {
+						c.WaitTimeout = waitTimeout
+					}
+					return c
+				}())
+				if err := rebootOrch.ExecuteReboot(ctx, client, pool, host.Addr, host.SSHPort, host.SSHUser); err != nil {
+					fmt.Printf("  reboot/wait failed: %v\n\n", err)
+					continue
+				}
+
+				client, err = pool.GetWithUser(ctx, host.Addr, host.SSHPort, host.SSHUser)
+				if err != nil {
+					fmt.Printf("  reconnect after reboot failed: %v\n\n", err)
+					continue
+				}
+				ok, got, _ := updater.VerifyRelease(ctx, client, wantVer)
+				if ok {
+					fmt.Printf("  VERIFIED: now on %s\n", got)
+				} else {
+					fmt.Printf("  WARNING: expected %s, host reports %s\n", wantVer, got)
+				}
+
+				if postHook != "" {
+					if _, err := client.ExecSudo(ctx, postHook); err != nil {
+						fmt.Printf("  post-hook warning: %v\n", err)
+					}
+				}
+				fmt.Printf("  %s done.\n\n", host.Name)
+			}
+
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&only, "only", "", "Upgrade just this host (by inventory name)")
+	cmd.Flags().StringVar(&target, "target", "", "Expected resulting version for verification (e.g. 26.04); auto-detected if empty")
+	cmd.Flags().BoolVar(&allowEOL, "allow-eol", false, "Allow upgrading an EOL release via apt sources codename rewrite")
+	cmd.Flags().StringVar(&nextCodename, "next-codename", "", "Next release codename for the EOL path (e.g. questing)")
+	cmd.Flags().StringSliceVar(&stopUnits, "stop-units", nil, "Systemd units to stop before upgrading (e.g. llama-rocm-foo.service)")
+	cmd.Flags().StringVar(&preHook, "pre-hook", "", "Extra sudo command to run before the upgrade (e.g. k0s drain)")
+	cmd.Flags().StringVar(&postHook, "post-hook", "", "Sudo command to run after verify (e.g. k0s uncordon)")
+	cmd.Flags().BoolVar(&noReboot, "no-reboot", false, "Do not reboot after the upgrade completes")
+	cmd.Flags().BoolVarP(&assumeYes, "yes", "y", false, "Do not prompt for per-host confirmation")
+	cmd.Flags().BoolVar(&checkOnly, "check", false, "Only report current/target release per host; make no changes")
+	cmd.Flags().DurationVar(&pollEvery, "poll", 30*time.Second, "How often to poll the detached upgrade for progress")
+	cmd.Flags().DurationVar(&waitTimeout, "wait-timeout", 30*time.Minute, "How long to wait for a host to return after reboot")
+
+	return cmd
 }
 
 func nixCmd() *cobra.Command {

--- a/cmd/nixfleet/main.go
+++ b/cmd/nixfleet/main.go
@@ -1173,11 +1173,21 @@ Always serial — one host at a time — to protect shared services.`,
 				if info.RunningEOL {
 					eolNote = " [running release is EOL]"
 				}
-				fmt.Printf("  current: %s (%s)%s  free /: %d MiB  target: %q\n",
-					info.CurrentVersion, info.Codename, eolNote, info.FreeRootMB, info.TargetRelease)
+				fmt.Printf("  current: %s (%s)%s  free /: %d MiB  free /boot: %d MiB  target: %q\n",
+					info.CurrentVersion, info.Codename, eolNote, info.FreeRootMB, info.FreeBootMB, info.TargetRelease)
 
 				if checkOnly {
 					fmt.Println()
+					continue
+				}
+
+				// /boot preflight up front — a too-small /boot breaks the prepare
+				// full-upgrade (new kernel initramfs) before we ever reach the
+				// release upgrade. Better to flag it here than half-configure a kernel.
+				cfgBoot := osupdate.DefaultReleaseUpgradeConfig()
+				if info.FreeBootMB > 0 && info.FreeBootMB < cfgBoot.MinFreeBootMB {
+					fmt.Printf("  SKIP: only %d MiB free on /boot (need ~%d). Remove old kernels or set initramfs MODULES=dep first.\n\n",
+						info.FreeBootMB, cfgBoot.MinFreeBootMB)
 					continue
 				}
 

--- a/cmd/nixfleet/main.go
+++ b/cmd/nixfleet/main.go
@@ -1097,6 +1097,7 @@ func osUpdateReleaseUpgradeCmd() *cobra.Command {
 		checkOnly    bool
 		pollEvery    time.Duration
 		waitTimeout  time.Duration
+		minFreeBoot  int64
 	)
 
 	cmd := &cobra.Command{
@@ -1185,8 +1186,11 @@ Always serial — one host at a time — to protect shared services.`,
 				// full-upgrade (new kernel initramfs) before we ever reach the
 				// release upgrade. Better to flag it here than half-configure a kernel.
 				cfgBoot := osupdate.DefaultReleaseUpgradeConfig()
-				if info.FreeBootMB > 0 && info.FreeBootMB < cfgBoot.MinFreeBootMB {
-					fmt.Printf("  SKIP: only %d MiB free on /boot (need ~%d). Remove old kernels or set initramfs MODULES=dep first.\n\n",
+				if minFreeBoot >= 0 {
+					cfgBoot.MinFreeBootMB = minFreeBoot
+				}
+				if cfgBoot.MinFreeBootMB > 0 && info.FreeBootMB > 0 && info.FreeBootMB < cfgBoot.MinFreeBootMB {
+					fmt.Printf("  SKIP: only %d MiB free on /boot (need ~%d). Remove old kernels, set initramfs MODULES=dep, or lower --min-free-boot.\n\n",
 						info.FreeBootMB, cfgBoot.MinFreeBootMB)
 					continue
 				}
@@ -1233,6 +1237,9 @@ Always serial — one host at a time — to protect shared services.`,
 				cfg.NextCodename = nextCodename
 				cfg.PreHook = preHookFull
 				cfg.PostHook = postHook
+				if minFreeBoot >= 0 {
+					cfg.MinFreeBootMB = minFreeBoot
+				}
 
 				fmt.Printf("  Preparing (set prompt, full-upgrade current release)...\n")
 				if err := updater.PrepareRelease(ctx, client); err != nil {
@@ -1318,6 +1325,7 @@ Always serial — one host at a time — to protect shared services.`,
 	cmd.Flags().BoolVar(&checkOnly, "check", false, "Only report current/target release per host; make no changes")
 	cmd.Flags().DurationVar(&pollEvery, "poll", 30*time.Second, "How often to poll the detached upgrade for progress")
 	cmd.Flags().DurationVar(&waitTimeout, "wait-timeout", 30*time.Minute, "How long to wait for a host to return after reboot")
+	cmd.Flags().Int64Var(&minFreeBoot, "min-free-boot", -1, "Override required free /boot MiB (-1 = default 350; lower for MODULES=dep nodes)")
 
 	return cmd
 }

--- a/cmd/nixfleet/main.go
+++ b/cmd/nixfleet/main.go
@@ -98,6 +98,7 @@ It provides Ansible-like UX for:
 	cmd.AddCommand(rollbackCmd())
 	cmd.AddCommand(statusCmd())
 	cmd.AddCommand(osUpdateCmd())
+	cmd.AddCommand(nixCmd())
 	cmd.AddCommand(rebootCmd())
 	cmd.AddCommand(cacheCmd())
 	cmd.AddCommand(secretsCmd())
@@ -1078,6 +1079,154 @@ func osUpdateUnholdCmd() *cobra.Command {
 			return nil
 		},
 	}
+}
+
+func nixCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "nix",
+		Short: "Manage the Nix flake inputs (nixpkgs) for the fleet",
+		Long:  `Update and deploy the Nix package set the fleet is built from.`,
+	}
+	cmd.AddCommand(nixUpdateCmd())
+	return cmd
+}
+
+func nixUpdateCmd() *cobra.Command {
+	var (
+		doApply    bool
+		skipVerify bool
+		skipState  bool
+		inputs     []string
+	)
+
+	cmd := &cobra.Command{
+		Use:   "update",
+		Short: "Update flake.lock (nixpkgs) and optionally deploy",
+		Long: `Run 'nix flake update' to refresh flake.lock, verify every host still
+evaluates with the new package set, and optionally build + deploy the result.
+
+By default only the 'nixpkgs' input is updated. Pass --input to target others
+(repeatable), or --input "" semantics are not supported — omit the flag to keep
+the default. Use --apply to roll the new closures out to all inventory hosts.`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := cmd.Context()
+
+			flake, err := nix.ResolveFlakePath(flakePath)
+			if err != nil {
+				return err
+			}
+			evaluator, err := nix.NewEvaluator(flake)
+			if err != nil {
+				return err
+			}
+
+			fmt.Printf("Updating flake inputs: %s\n", strings.Join(inputs, ", "))
+			out, err := evaluator.FlakeUpdate(ctx, inputs...)
+			if out != "" {
+				fmt.Println(strings.TrimRight(out, "\n"))
+			}
+			if err != nil {
+				return err
+			}
+
+			if !strings.Contains(out, "Updated input") {
+				fmt.Println("\nflake.lock already up to date — nothing to do.")
+				return nil
+			}
+
+			_, hosts, err := loadInventoryAndHosts(ctx)
+			if err != nil {
+				return err
+			}
+
+			// Verify every host still evaluates before we consider deploying.
+			if !skipVerify {
+				fmt.Printf("\nVerifying %d host(s) still evaluate...\n", len(hosts))
+				var broken []string
+				for _, host := range hosts {
+					if _, err := evaluator.EvalHost(ctx, host.Name, host.Base); err != nil {
+						fmt.Printf("  %s: EVAL FAILED - %v\n", host.Name, err)
+						broken = append(broken, host.Name)
+					} else if verbose {
+						fmt.Printf("  %s: ok\n", host.Name)
+					}
+				}
+				if len(broken) > 0 {
+					return fmt.Errorf("%d host(s) fail to evaluate with updated nixpkgs: %s (flake.lock left updated; fix or `git checkout flake.lock`)", len(broken), strings.Join(broken, ", "))
+				}
+				fmt.Printf("All %d host(s) evaluate cleanly.\n", len(hosts))
+			}
+
+			if !doApply {
+				fmt.Println("\nflake.lock updated. Run `nixfleet apply` (or re-run with --apply) to deploy.")
+				return nil
+			}
+
+			// Deploy: build + copy + activate each host. This intentionally does
+			// not run preflight/PKI (see `nixfleet apply` for the full pipeline);
+			// a package-set bump only needs the closure rolled out.
+			deployer := nix.NewDeployer(evaluator)
+			pool := ssh.NewPool(nil)
+			defer pool.Close()
+			stateMgr := state.NewManager()
+
+			fmt.Printf("\nDeploying updated closures to %d host(s)...\n\n", len(hosts))
+			success, failed := 0, 0
+			for _, host := range hosts {
+				fmt.Printf("Deploying to %s...\n", host.Name)
+				startTime := time.Now()
+
+				closure, err := evaluator.BuildHost(ctx, host.Name, host.Base)
+				if err != nil {
+					fmt.Printf("  Build failed: %v\n", err)
+					failed++
+					continue
+				}
+				if err := deployer.CopyToHost(ctx, closure, host); err != nil {
+					fmt.Printf("  Copy failed: %v\n", err)
+					failed++
+					continue
+				}
+				client, err := pool.GetWithUser(ctx, host.Addr, host.SSHPort, host.SSHUser)
+				if err != nil {
+					fmt.Printf("  Connection failed: %v\n", err)
+					failed++
+					continue
+				}
+				switch host.Base {
+				case "ubuntu":
+					err = deployer.ActivateUbuntu(ctx, client, closure)
+				case "nixos":
+					err = deployer.ActivateNixOS(ctx, client, closure, "switch")
+				}
+				if err != nil {
+					fmt.Printf("  Activation failed: %v\n", err)
+					failed++
+					continue
+				}
+				if !skipState {
+					gen, _, _ := deployer.GetCurrentGeneration(ctx, client, host.Base)
+					if err := stateMgr.UpdateAfterApply(ctx, client, closure.StorePath, closure.ManifestHash, gen, time.Since(startTime)); err != nil {
+						fmt.Printf("  Warning: failed to update state - %v\n", err)
+					}
+				}
+				fmt.Printf("  Done! (%s)\n\n", time.Since(startTime).Round(time.Second))
+				success++
+			}
+			fmt.Printf("Summary: %d succeeded, %d failed\n", success, failed)
+			if failed > 0 {
+				return fmt.Errorf("%d host(s) failed to deploy", failed)
+			}
+			return nil
+		},
+	}
+
+	cmd.Flags().BoolVar(&doApply, "apply", false, "Build and deploy updated closures to all hosts after updating")
+	cmd.Flags().BoolVar(&skipVerify, "skip-verify", false, "Skip re-evaluating all hosts after the lock update")
+	cmd.Flags().BoolVar(&skipState, "skip-state", false, "Skip updating host state after deploy (with --apply)")
+	cmd.Flags().StringSliceVar(&inputs, "input", []string{"nixpkgs"}, "Flake inputs to update (repeatable)")
+
+	return cmd
 }
 
 func rebootCmd() *cobra.Command {

--- a/flake.lock
+++ b/flake.lock
@@ -60,11 +60,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1766309749,
-        "narHash": "sha256-3xY8CZ4rSnQ0NqGhMKAy5vgC+2IVK0NoVEzDoOh4DA4=",
+        "lastModified": 1781577229,
+        "narHash": "sha256-lrp67w8AulE9Ks53n27I45ADSzbOCn4H+CNW1Ck8B+8=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "a6531044f6d0bef691ea18d4d4ce44d0daa6e816",
+        "rev": "567a49d1913ce81ac6e9582e3553dd90a955875f",
         "type": "github"
       },
       "original": {

--- a/modules/backup.nix
+++ b/modules/backup.nix
@@ -1,9 +1,10 @@
 # NixFleet Backup Module
 # Configures SMB personal drive mounts, NFS backup mounts, and ZFS snapshot backups
-{ config
-, pkgs
-, lib
-, ...
+{
+  config,
+  pkgs,
+  lib,
+  ...
 }:
 {
   # ============================================================================
@@ -76,13 +77,6 @@
           echo "[$(date '+%Y-%m-%d %H:%M:%S')] $*" | tee -a "$LOG_FILE"
         }
 
-        check_mount() {
-          if ! mountpoint -q "$BACKUP_MOUNT"; then
-            log "ERROR: Backup mount $BACKUP_MOUNT not mounted"
-            exit 1
-          fi
-        }
-
         create_snapshot() {
           local pool=$1
           local snap_name="nixfleet-$(date +%Y%m%d-%H%M%S)"
@@ -114,8 +108,16 @@
           local pool=$1
           log "Cleaning up snapshots older than $RETENTION_DAYS days for $pool"
 
-          zfs list -t snapshot -o name,creation -p "$pool" 2>/dev/null | \
-            grep "nixfleet-" | while read snap creation; do
+          # IMPORTANT: -r is required. Snapshots are created with `zfs snapshot -r`
+          # (recursive over every child dataset), so without -r here we only ever
+          # see/destroy the top-level pool snapshot and the child-dataset
+          # snapshots (e.g. bpool/BOOT/ubuntu_*@nixfleet-...) accumulate forever
+          # until the pool fills — which is exactly how a 1.88 GiB bpool reached
+          # 92% with 178 un-pruned /boot snapshots. Listing recursively and
+          # destroying each enumerated snapshot also cleans up any pre-existing
+          # orphans left by the previous non-recursive logic.
+          zfs list -t snapshot -r -o name,creation -p "$pool" 2>/dev/null | \
+            grep "nixfleet-" | while read -r snap creation; do
               age_days=$(( ($(date +%s) - creation) / 86400 ))
               if [ "$age_days" -gt "$RETENTION_DAYS" ]; then
                 log "Removing old snapshot: $snap"
@@ -132,24 +134,40 @@
         main() {
           log "=== ZFS Backup Started ==="
 
-          check_mount
+          # Local snapshotting + retention must NOT depend on the remote backup
+          # mount being available. Previously main() ran check_mount first and
+          # exited, so when the backup NAS was unreachable nothing ran — but the
+          # bigger hazard is the opposite: if snapshots are created without
+          # cleanup ever running, the pool fills. So we always create + prune
+          # snapshots locally, and only perform the off-host send when the mount
+          # is present.
+          local have_mount=false
+          if mountpoint -q "$BACKUP_MOUNT"; then
+            have_mount=true
+          else
+            log "WARN: backup mount $BACKUP_MOUNT not available — snapshotting locally, skipping off-host send"
+          fi
 
           # Get all ZFS pools
           for pool in $(zpool list -Ho name); do
             log "Processing pool: $pool"
 
-            # Create snapshot
+            # Create snapshot (recursive)
             snap_name=$(create_snapshot "$pool")
 
-            # Backup snapshot
-            backup_snapshot "$pool" "$snap_name"
+            # Send off-host only when the backup mount is present
+            if [ "$have_mount" = true ]; then
+              backup_snapshot "$pool" "$snap_name"
+            fi
 
-            # Cleanup old snapshots
+            # Always prune old snapshots so the pool can't fill
             cleanup_old_snapshots "$pool"
           done
 
-          # Cleanup old backup files
-          cleanup_old_backups
+          # Cleanup old backup files (only meaningful when the mount is present)
+          if [ "$have_mount" = true ]; then
+            cleanup_old_backups
+          fi
 
           log "=== ZFS Backup Completed ==="
         }

--- a/modules/llm-inference.nix
+++ b/modules/llm-inference.nix
@@ -299,29 +299,42 @@ let
     in
     "${svc.binary} \\\n  ${concatStringsSep " \\\n  " flags}";
 
-  # Generate systemd unit text
-  mkUnit = name: svc: ''
-    [Unit]
-    Description=${svc.description}
-    After=network.target
-    Wants=dev-kfd.device
-    After=dev-kfd.device
+  # Generate systemd unit text.
+  #
+  # `index` is this service's position among the host's inference services and
+  # drives a startup stagger: multiple llama-server processes hitting the ROCm
+  # allocator at the same instant (e.g. all cold-starting on boot, or all
+  # restarting on apply) race and SEGV during model load on the shared iGPU.
+  # A per-service `sleep (index * startStaggerSec)` spreads their inits apart so
+  # the GPU memory allocations don't collide. index 0 gets no delay.
+  mkUnit =
+    name: svc: index:
+    let
+      staggerSec = index * cfg.startStaggerSec;
+    in
+    ''
+      [Unit]
+      Description=${svc.description}
+      After=network.target
+      Wants=dev-kfd.device
+      After=dev-kfd.device
 
-    [Service]
-    Type=simple
-    User=deploy
-    SupplementaryGroups=render video
-    Environment=LD_LIBRARY_PATH=${svc.ldLibraryPath}
-    ${concatStringsSep "\n" (mapAttrsToList (k: v: "Environment=${k}=${v}") svc.rocmEnv)}
-    ExecStartPre=/bin/bash -c 'for i in $(seq 1 30); do [ -e /dev/kfd ] && exit 0; sleep 1; done; echo "WARNING: /dev/kfd not found after 30s"'
-    ExecStart=${mkExecStart name svc}
-    Restart=on-failure
-    RestartSec=10
-    LimitMEMLOCK=infinity
+      [Service]
+      Type=simple
+      User=deploy
+      SupplementaryGroups=render video
+      Environment=LD_LIBRARY_PATH=${svc.ldLibraryPath}
+      ${concatStringsSep "\n" (mapAttrsToList (k: v: "Environment=${k}=${v}") svc.rocmEnv)}
+      ${optionalString (staggerSec > 0) "ExecStartPre=/bin/sleep ${toString staggerSec}"}
+      ExecStartPre=/bin/bash -c 'for i in $(seq 1 30); do [ -e /dev/kfd ] && exit 0; sleep 1; done; echo "WARNING: /dev/kfd not found after 30s"'
+      ExecStart=${mkExecStart name svc}
+      Restart=on-failure
+      RestartSec=10
+      LimitMEMLOCK=infinity
 
-    [Install]
-    WantedBy=multi-user.target
-  '';
+      [Install]
+      WantedBy=multi-user.target
+    '';
 
 in
 {
@@ -334,6 +347,18 @@ in
       description = "Path to ROCm-enabled llama.cpp libs";
     };
 
+    startStaggerSec = mkOption {
+      type = types.int;
+      default = 15;
+      description = ''
+        Seconds to stagger each successive inference service's start, so that
+        multiple llama-server processes do not initialise the shared iGPU
+        (ROCm allocator) at the same instant and SEGV during model load. The
+        Nth service (by sorted name) sleeps N*startStaggerSec before launching.
+        Set to 0 to disable staggering.
+      '';
+    };
+
     services = mkOption {
       type = types.attrsOf serviceType;
       default = { };
@@ -342,12 +367,16 @@ in
   };
 
   config = mkIf cfg.enable {
-    nixfleet.systemd.units = mapAttrs' (
-      name: svc:
-      nameValuePair "llama-rocm-${name}.service" {
-        text = mkUnit name svc;
-        enabled = svc.enable;
-      }
-    ) cfg.services;
+    # imap0 over the sorted service names gives each a stable index for the
+    # startup stagger (see mkUnit).
+    nixfleet.systemd.units = listToAttrs (
+      imap0 (
+        index: name:
+        nameValuePair "llama-rocm-${name}.service" {
+          text = mkUnit name cfg.services.${name} index;
+          enabled = cfg.services.${name}.enable;
+        }
+      ) (attrNames cfg.services)
+    );
   };
 }

--- a/modules/llm-inference.nix
+++ b/modules/llm-inference.nix
@@ -334,6 +334,11 @@ let
       ExecStart=${mkExecStart name svc}
       Restart=on-failure
       RestartSec=10
+      # TimeoutStartSec must exceed the stagger sleep (which runs in ExecStartPre
+      # and counts toward the start timeout) plus the /dev/kfd poll, or the
+      # higher-index services get killed mid-stagger with result 'timeout' and
+      # crash-loop. systemd's 90s default is too small once the stagger grows.
+      TimeoutStartSec=${toString (staggerSec + 120)}
       LimitMEMLOCK=infinity
 
       [Install]

--- a/modules/llm-inference.nix
+++ b/modules/llm-inference.nix
@@ -316,8 +316,12 @@ let
       [Unit]
       Description=${svc.description}
       After=network.target
-      Wants=dev-kfd.device
-      After=dev-kfd.device
+      # NB: deliberately NO Wants/After=dev-kfd.device. The amdkfd device does
+      # not activate as a systemd .device unit (it stays inactive/dead even
+      # though /dev/kfd exists), so an After=dev-kfd.device ordering stalls the
+      # service's start job forever at boot — the unit never auto-starts after a
+      # reboot. GPU readiness is instead handled robustly by the ExecStartPre
+      # below, which polls for /dev/kfd directly.
 
       [Service]
       Type=simple

--- a/modules/nixfleet/options.nix
+++ b/modules/nixfleet/options.nix
@@ -348,6 +348,40 @@ in
       description = "Packages to install via Nix profile";
     };
 
+    # Declarative APT package management (Ubuntu hosts only).
+    #
+    # Complements nixfleet.packages (Nix profile) for things that must live in
+    # the host's native package set — kernel/DKMS modules, GPU userspace (ROCm),
+    # drivers, anything that has to integrate with the distro. The Ubuntu backend
+    # reconciles these in the activation script; the NixOS/Darwin backends ignore
+    # them. Reconciliation is drift-only: apt is touched solely when a declared
+    # package is missing/present-but-should-be-absent/not-held.
+    apt = {
+      packages = mkOption {
+        type = types.listOf types.str;
+        default = [ ];
+        example = [
+          "nfs-common"
+          "rocm-smi"
+        ];
+        description = "APT packages to ensure are installed.";
+      };
+
+      absent = mkOption {
+        type = types.listOf types.str;
+        default = [ ];
+        example = [ "snapd" ];
+        description = "APT packages to ensure are removed.";
+      };
+
+      hold = mkOption {
+        type = types.listOf types.str;
+        default = [ ];
+        example = [ "linux-image-generic" ];
+        description = "APT packages to mark held (apt-mark hold) so upgrades skip them.";
+      };
+    };
+
     # Managed files
     files = mkOption {
       type = types.attrsOf fileType;


### PR DESCRIPTION
## Summary

Fleet package + OS modernization: bumps Nix pkgs to latest, adds the missing package-management tooling to NixFleet, and lands the OS release-upgrade path (Ubuntu → 26.04 LTS). Validated end-to-end by upgrading **gtr-153 to 26.04 LTS** (kernel 7.0.0) — GPU/ROCm (gfx1151), TPM2 ZFS-on-LUKS unlock, and inference auto-recovery all confirmed working.

## What's included

**Package management (the "fill the gaps" asks)**
- `chore(flake)`: nixpkgs `2025-12-21 → 2026-06-16` (was ~6 months stale); deployed fleet-wide.
- `feat(apt)`: declarative `nixfleet.apt.{packages,absent,hold}` — reconciled in activation, folded into the manifest hash. Native apt packages (kernel/DKMS, ROCm userspace, drivers) can now be declared, not just imperatively managed.
- `feat(nix)`: `nixfleet nix update` — `nix flake update` → re-eval every host (catch breakage) → optional `--apply`.

**OS release-upgrade orchestration**
- `feat(os-update)`: `nixfleet os-update release-upgrade` — serial, per-host, **detached via systemd-run** (survives SSH drops), `--check`/`--stop-units`/`--pre-hook`/`--post-hook`/`--allow-eol`, exit-code via sentinel file (never reboots on a failed upgrade), free-disk **and** `/boot` preflight + `--min-free-boot` override.

**Fixes the gtr-153 canary forced out**
- `fix(backup)`: recursive snapshot pruning. Snapshots were *created* with `zfs snapshot -r` but pruned non-recursively, so child-dataset snapshots accumulated until the bpool filled (178 snapshots / 1.59 GiB on gtr-153's 228 MiB bpool, blocking kernel initramfs builds). Also decoupled local snapshot+prune from the (dead-NAS) remote mount.
- `fix(llm-inference)`: stagger GPU service starts (avoid simultaneous ROCm-init SEGV on boot/apply) + drop the `dev-kfd.device` dependency that stalled boot auto-start (the amdkfd device never activates as a systemd `.device` unit).

## Validation

gtr-153: `25.10 → 26.04 LTS (resolute, kernel 7.0.0-22)`, ROCm inference returns tokens on the new kernel, ZFS+TPM2 unlock works, qwopus auto-recovers ~52s post-boot, dpkg clean.

## Remaining (separate work)

- gti (`25.10 → 26.04`, control plane, 1 hop)
- gtr-150/151/152 (`25.04 EOL → 25.10 → 26.04`, 2 hops each)
- Deploy backup fix fleet-wide to prune accumulated snapshots (gti ~400, gtr-153 rpool)

## Procedure notes (learned)

Do **not** `apt-mark hold` GPU/ROCm packages before a release-upgrade — it jams do-release-upgrade's dependency solver, and is unnecessary (ROCm survives via bundled `/opt/llama-rocm` libs; the AMD `noble` apt repos get left in place and still resolve).
