### PR TITLE
fix: backup runs without NAS mount + non-blocking unit restarts

### DIFF
--- a/backends/ubuntu/compile.nix
+++ b/backends/ubuntu/compile.nix
@@ -801,7 +801,14 @@ let
     if [ -n "$UNITS_TO_RESTART" ]; then
       log "Restarting affected units:$UNITS_TO_RESTART"
       for unit in $UNITS_TO_RESTART; do
-        systemctl restart "$unit" 2>/dev/null || log "  Warning: Failed to restart $unit"
+        # --no-block: queue the restart and move on instead of waiting for the
+        # unit to become active. GPU inference units carry a startup-stagger
+        # sleep in ExecStartPre, so a blocking restart serialized across many of
+        # them (e.g. gtr-150's 9 services) holds the activation SSH session open
+        # for minutes until it times out ("remote command exited without exit
+        # status"). Async restart lets the stagger do its job without stalling
+        # activation; post-apply health checks verify the units came up.
+        systemctl restart --no-block "$unit" 2>/dev/null || log "  Warning: Failed to queue restart of $unit"
       done
     fi
 

--- a/modules/backup.nix
+++ b/modules/backup.nix
@@ -334,8 +334,12 @@
       text = ''
         [Unit]
         Description=ZFS snapshot backup to NFS
+        # Wants, not Requires: the script snapshots + prunes locally regardless of
+        # the backup mount (only the off-host send needs it). A hard Requires meant
+        # that when the backup NAS was unreachable the service never ran at all, so
+        # nothing pruned and the pools filled. After= keeps ordering when present.
         After=mnt-backup.mount
-        Requires=mnt-backup.mount
+        Wants=mnt-backup.mount
 
         [Service]
         Type=oneshot


### PR DESCRIPTION
Follow-ups from the 26.04 fleet rollout:

- **zfs-backup.service**: `Requires=mnt-backup.mount` → `Wants=`. The script snapshots+prunes locally regardless of the (dead `.95`) backup NAS; a hard Requires meant it never ran when the NAS was down, so nothing pruned and pools filled. (Note: no deployed host currently imports backup.nix — adopt it on the ZFS-root hosts as part of the NAS migration.)
- **activation restart loop**: `systemctl restart --no-block`. GPU inference units carry a startup-stagger sleep in ExecStartPre; a blocking restart serialized across many of them (gtr-150's 9) held the activation SSH session open until it timed out into a false 'Activation failed'. Verified clean on gtr-153 (9s apply, no false-fail).

Surfaced separately (not changed here — your call): gti expects an NVIDIA GPU (Flux/Helm device-plugin + a GPU-requesting workload) but has only an Intel Arc Pro; gtr-152 has 2 hand-tuned undeclared models; gtr-153 has 3 disabled broken `@instance`s.