### PR TITLE
feat(synology): Model-B DSM-API backend (iSCSI LUNs + NFS exports)

### DIFF
--- a/cmd/nixfleet/internal/nix/evaluator.go
+++ b/cmd/nixfleet/internal/nix/evaluator.go
@@ -81,6 +81,24 @@ func (e *Evaluator) EvalHost(ctx context.Context, hostName string, base string) 
 	}, nil
 }
 
+// EvalAttrJSON evaluates an arbitrary flake attribute to JSON (e.g.
+// "nixfleetConfigurations.znas.synology"). Used by API-driven backends that
+// reconcile a declarative spec rather than building/copying a closure.
+func (e *Evaluator) EvalAttrJSON(ctx context.Context, attr string) ([]byte, error) {
+	flakeRef := fmt.Sprintf("%s#%s", e.flakePath, attr)
+	cmd := exec.CommandContext(ctx, e.nixBin, "eval", "--json", flakeRef)
+	cmd.Dir = e.flakePath
+
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	if err := cmd.Run(); err != nil {
+		return nil, fmt.Errorf("nix eval %s failed: %w\nstderr: %s", attr, err, stderr.String())
+	}
+	return stdout.Bytes(), nil
+}
+
 // BuildHost builds a host configuration and returns the store path
 func (e *Evaluator) BuildHost(ctx context.Context, hostName string, base string) (*HostClosure, error) {
 	var attr string

--- a/cmd/nixfleet/internal/synology/client.go
+++ b/cmd/nixfleet/internal/synology/client.go
@@ -1,0 +1,183 @@
+package synology
+
+import (
+	"context"
+	"crypto/tls"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"time"
+)
+
+// Client talks to the Synology DSM Web API over HTTPS using a session id (sid).
+// DSM presents a self-signed cert, so TLS verification is skipped (the host is
+// reached over the trusted LAN, same as the synology-csi driver).
+type Client struct {
+	baseURL string
+	user    string
+	passwd  string
+	sid     string
+	http    *http.Client
+}
+
+// NewClient builds a client for the given DSM host. Password is supplied
+// separately (sourced from 1Password/env by the caller) and never logged.
+func NewClient(host string, port int, https bool, user, passwd string) *Client {
+	scheme := "https"
+	if !https {
+		scheme = "http"
+	}
+	return &Client{
+		baseURL: fmt.Sprintf("%s://%s:%d/webapi", scheme, host, port),
+		user:    user,
+		passwd:  passwd,
+		http: &http.Client{
+			Timeout: 30 * time.Second,
+			Transport: &http.Transport{
+				TLSClientConfig: &tls.Config{InsecureSkipVerify: true}, //nolint:gosec // DSM self-signed cert on trusted LAN
+			},
+		},
+	}
+}
+
+// apiResponse is the standard DSM envelope.
+type apiResponse struct {
+	Success bool            `json:"success"`
+	Data    json.RawMessage `json:"data"`
+	Error   *struct {
+		Code int `json:"code"`
+	} `json:"error"`
+}
+
+// Login authenticates and stores the session id. Must be called before any API
+// call. format=sid returns the sid in the body (no cookie juggling).
+func (c *Client) Login(ctx context.Context) error {
+	q := url.Values{
+		"api":     {"SYNO.API.Auth"},
+		"version": {"3"},
+		"method":  {"login"},
+		"account": {c.user},
+		"passwd":  {c.passwd},
+		"session": {"NixFleet"},
+		"format":  {"sid"},
+	}
+	var out struct {
+		SID string `json:"sid"`
+	}
+	if err := c.do(ctx, "auth.cgi", q, &out); err != nil {
+		return fmt.Errorf("DSM login failed for %s: %w", c.user, err)
+	}
+	if out.SID == "" {
+		return fmt.Errorf("DSM login returned no session id")
+	}
+	c.sid = out.SID
+	return nil
+}
+
+// Logout invalidates the session. Safe to call with no session.
+func (c *Client) Logout(ctx context.Context) {
+	if c.sid == "" {
+		return
+	}
+	q := url.Values{
+		"api":     {"SYNO.API.Auth"},
+		"version": {"3"},
+		"method":  {"logout"},
+		"session": {"NixFleet"},
+	}
+	_ = c.do(ctx, "auth.cgi", q, nil) // best-effort
+	c.sid = ""
+}
+
+// get calls an entry.cgi API method (read or write) and decodes data into out.
+func (c *Client) get(ctx context.Context, api, method string, version int, extra url.Values) (json.RawMessage, error) {
+	q := url.Values{
+		"api":     {api},
+		"version": {fmt.Sprintf("%d", version)},
+		"method":  {method},
+	}
+	if c.sid != "" {
+		q.Set("_sid", c.sid)
+	}
+	for k, vs := range extra {
+		for _, v := range vs {
+			q.Add(k, v)
+		}
+	}
+	var raw json.RawMessage
+	if err := c.do(ctx, "entry.cgi", q, &rawCapture{&raw}); err != nil {
+		return nil, err
+	}
+	return raw, nil
+}
+
+// rawCapture lets do() hand back the raw data payload.
+type rawCapture struct{ into *json.RawMessage }
+
+// do issues the request, checks the DSM envelope, and decodes data into out.
+// out may be nil (ignore data), a *rawCapture (keep raw), or any json target.
+func (c *Client) do(ctx context.Context, cgi string, q url.Values, out any) error {
+	reqURL := c.baseURL + "/" + cgi + "?" + q.Encode()
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, reqURL, nil)
+	if err != nil {
+		return err
+	}
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return fmt.Errorf("request to %s: %w", cgi, err)
+	}
+	defer resp.Body.Close()
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 8<<20))
+	if err != nil {
+		return err
+	}
+	var env apiResponse
+	if err := json.Unmarshal(body, &env); err != nil {
+		return fmt.Errorf("decode %s response: %w", cgi, err)
+	}
+	if !env.Success {
+		code := -1
+		if env.Error != nil {
+			code = env.Error.Code
+		}
+		return fmt.Errorf("DSM API %s error: code %d (%s)", cgi, code, dsmErrText(code))
+	}
+	switch t := out.(type) {
+	case nil:
+		return nil
+	case *rawCapture:
+		*t.into = env.Data
+		return nil
+	default:
+		if len(env.Data) == 0 {
+			return nil
+		}
+		return json.Unmarshal(env.Data, out)
+	}
+}
+
+// unmarshalData decodes a raw DSM data payload, tolerating an empty payload.
+func unmarshalData(raw json.RawMessage, out any) error {
+	if len(raw) == 0 {
+		return nil
+	}
+	return json.Unmarshal(raw, out)
+}
+
+// dsmErrText maps common DSM auth/API error codes to a hint.
+func dsmErrText(code int) string {
+	switch code {
+	case 400, 401:
+		return "invalid credentials"
+	case 403:
+		return "2FA/OTP required — not supported by this backend"
+	case 105:
+		return "insufficient permission for this account"
+	case 119:
+		return "session expired"
+	default:
+		return "see DSM API error reference"
+	}
+}

--- a/cmd/nixfleet/internal/synology/config.go
+++ b/cmd/nixfleet/internal/synology/config.go
@@ -1,0 +1,99 @@
+// Package synology implements nixfleet's Model-B backend: declarative management
+// of a Synology NAS via the DSM Web API (not SSH). Desired state is declared in
+// Nix under nixfleet.synology and reconciled here. This slice covers iSCSI LUNs
+// and NFS exports — the resources the k0s CSI driver and backups already depend on.
+package synology
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+// Config is the desired DSM state, produced by
+// `nix eval --json .#nixfleetConfigurations.<host>.synology`.
+type Config struct {
+	Enable     bool        `json:"enable"`
+	Host       string      `json:"host"`
+	Port       int         `json:"port"`
+	HTTPS      bool        `json:"https"`
+	User       string      `json:"user"`
+	ISCSILUNs  []LUN       `json:"iscsiLuns"`
+	NFSExports []NFSExport `json:"nfsExports"`
+}
+
+// LUN is a declared iSCSI LUN.
+type LUN struct {
+	Name            string `json:"name"`
+	Location        string `json:"location"` // e.g. /volume1
+	Size            string `json:"size"`     // human size, e.g. "500G"
+	Type            string `json:"type"`     // THIN | FILE | ADV
+	ThinProvisioned bool   `json:"thinProvisioned"`
+	Description     string `json:"description"`
+	CanSnapshot     bool   `json:"canSnapshot"`
+}
+
+// NFSExport is a declared NFS-shared folder.
+type NFSExport struct {
+	Name  string    `json:"name"`  // share name (and default path component)
+	Path  string    `json:"path"`  // optional; defaults to <vol>/<name>
+	Rules []NFSRule `json:"rules"` // NFS client access rules
+}
+
+// NFSRule is one NFS client access entry.
+type NFSRule struct {
+	Client string `json:"client"` // IP, CIDR, hostname, or *
+	Access string `json:"access"` // "rw" | "ro"
+	Squash string `json:"squash"` // "root_squash" | "all_squash" | "no_mapping"
+	Secure bool   `json:"secure"` // require source port < 1024
+	Async  bool   `json:"async"`  // async writes
+}
+
+// SizeBytes converts the human size (e.g. "500G", "1T", "10737418240") to bytes.
+func (l LUN) SizeBytes() (int64, error) {
+	return parseSize(l.Size)
+}
+
+var sizeUnits = []struct {
+	suffix string
+	mult   int64
+}{
+	{"T", 1 << 40}, {"G", 1 << 30}, {"M", 1 << 20}, {"K", 1 << 10},
+}
+
+func parseSize(s string) (int64, error) {
+	s = strings.TrimSpace(strings.ToUpper(s))
+	if s == "" {
+		return 0, fmt.Errorf("empty size")
+	}
+	s = strings.TrimSuffix(s, "B") // accept GB/TB as G/T
+	for _, u := range sizeUnits {
+		if strings.HasSuffix(s, u.suffix) {
+			n, err := strconv.ParseFloat(strings.TrimSuffix(s, u.suffix), 64)
+			if err != nil {
+				return 0, fmt.Errorf("invalid size %q: %w", s, err)
+			}
+			return int64(n * float64(u.mult)), nil
+		}
+	}
+	// plain byte count
+	n, err := strconv.ParseInt(s, 10, 64)
+	if err != nil {
+		return 0, fmt.Errorf("invalid size %q (use e.g. 500G, 1T, or a byte count)", s)
+	}
+	return n, nil
+}
+
+// lunType maps the friendly type to the DSM LUN type string.
+func (l LUN) dsmType() string {
+	switch strings.ToUpper(l.Type) {
+	case "", "THIN":
+		return "THIN"
+	case "FILE", "THICK":
+		return "FILE"
+	case "ADV", "ADVANCED":
+		return "ADV"
+	default:
+		return strings.ToUpper(l.Type)
+	}
+}

--- a/cmd/nixfleet/internal/synology/config.go
+++ b/cmd/nixfleet/internal/synology/config.go
@@ -20,6 +20,7 @@ type Config struct {
 	User       string      `json:"user"`
 	ISCSILUNs  []LUN       `json:"iscsiLuns"`
 	NFSExports []NFSExport `json:"nfsExports"`
+	Settings   []Setting   `json:"settings"` // generic DSM api/method/params calls
 }
 
 // LUN is a declared iSCSI LUN.

--- a/cmd/nixfleet/internal/synology/iscsi.go
+++ b/cmd/nixfleet/internal/synology/iscsi.go
@@ -1,0 +1,98 @@
+package synology
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"strconv"
+)
+
+// ActualLUN is an iSCSI LUN as reported by DSM.
+type ActualLUN struct {
+	UUID     string `json:"uuid"`
+	Name     string `json:"name"`
+	Size     int64  `json:"size"` // bytes
+	Type     string `json:"type"`
+	Location string `json:"location"`
+	LunID    int    `json:"lun_id"`
+}
+
+// ListLUNs returns all iSCSI LUNs on the NAS.
+func (c *Client) ListLUNs(ctx context.Context) ([]ActualLUN, error) {
+	raw, err := c.get(ctx, "SYNO.Core.ISCSI.LUN", "list", 1, nil)
+	if err != nil {
+		return nil, fmt.Errorf("list LUNs: %w", err)
+	}
+	var data struct {
+		LUNs []ActualLUN `json:"luns"`
+	}
+	if err := unmarshalData(raw, &data); err != nil {
+		return nil, fmt.Errorf("decode LUN list: %w", err)
+	}
+	return data.LUNs, nil
+}
+
+// CreateLUN creates a new iSCSI LUN from a declared spec.
+//
+// NOTE: DSM's LUN `type` is storage-backend specific. On a btrfs volume (our
+// .67 /volume1) thin LUNs are type "BLUN" — which is what the friendly "THIN"
+// maps to here, matching what the synology-csi driver creates. Verify against
+// `synology status` (the actual type of existing LUNs) before trusting create.
+func (c *Client) CreateLUN(ctx context.Context, l LUN) (string, error) {
+	sz, err := l.SizeBytes()
+	if err != nil {
+		return "", err
+	}
+	q := url.Values{
+		"name":        {l.Name},
+		"type":        {dsmCreateType(l)},
+		"location":    {l.Location},
+		"size":        {strconv.FormatInt(sz, 10)},
+		"description": {l.Description},
+	}
+	if l.CanSnapshot {
+		q.Set("can_snapshot", "true")
+	}
+	raw, err := c.get(ctx, "SYNO.Core.ISCSI.LUN", "create", 1, q)
+	if err != nil {
+		return "", fmt.Errorf("create LUN %q: %w", l.Name, err)
+	}
+	var data struct {
+		UUID string `json:"uuid"`
+	}
+	_ = unmarshalData(raw, &data)
+	return data.UUID, nil
+}
+
+// GrowLUN expands a LUN to newSize bytes (online grow only; DSM rejects shrink).
+// Gated behind --allow-resize. Validate against your DSM before relying on it.
+func (c *Client) GrowLUN(ctx context.Context, uuid string, newSize int64) error {
+	q := url.Values{
+		"uuid": {uuid},
+		"size": {strconv.FormatInt(newSize, 10)},
+	}
+	if _, err := c.get(ctx, "SYNO.Core.ISCSI.LUN", "set", 1, q); err != nil {
+		return fmt.Errorf("grow LUN %s: %w", uuid, err)
+	}
+	return nil
+}
+
+// DeleteLUN deletes a LUN by uuid (destructive — caller must gate on --prune).
+func (c *Client) DeleteLUN(ctx context.Context, uuid string) error {
+	q := url.Values{"uuid": {uuid}}
+	if _, err := c.get(ctx, "SYNO.Core.ISCSI.LUN", "safe_delete", 1, q); err != nil {
+		return fmt.Errorf("delete LUN %s: %w", uuid, err)
+	}
+	return nil
+}
+
+// dsmCreateType maps the friendly LUN type to the DSM create `type` string.
+// THIN on btrfs => BLUN; thick/file => FILE; advanced => ADV.
+func dsmCreateType(l LUN) string {
+	switch l.dsmType() {
+	case "THIN":
+		return "BLUN"
+	default:
+		return l.dsmType()
+	}
+}

--- a/cmd/nixfleet/internal/synology/nfs.go
+++ b/cmd/nixfleet/internal/synology/nfs.go
@@ -5,28 +5,19 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/url"
+	"sort"
 	"strings"
 )
 
-// ActualShare is a shared folder as reported by DSM, including its NFS rules.
+// ActualShare is a shared folder as reported by SYNO.Core.Share list.
 type ActualShare struct {
-	Name     string          `json:"name"`
-	VolPath  string          `json:"vol_path"` // e.g. /volume1
-	NFSRules json.RawMessage `json:"nfs_rule"` // raw; schema varies by DSM version
+	Name    string `json:"name"`
+	VolPath string `json:"vol_path"` // e.g. /volume1
 }
 
-// HasNFS reports whether the share has any NFS rules configured.
-func (s ActualShare) HasNFS() bool {
-	t := strings.TrimSpace(string(s.NFSRules))
-	return t != "" && t != "null" && t != "[]"
-}
-
-// ListShares returns all shared folders with their NFS rules.
+// ListShares returns all shared folders.
 func (c *Client) ListShares(ctx context.Context) ([]ActualShare, error) {
-	q := url.Values{
-		// request the nfs_rule + volume info in the listing
-		"additional": {`["nfs_rule","vol_path"]`},
-	}
+	q := url.Values{"additional": {`["vol_path"]`}}
 	raw, err := c.get(ctx, "SYNO.Core.Share", "list", 1, q)
 	if err != nil {
 		return nil, fmt.Errorf("list shares: %w", err)
@@ -40,63 +31,112 @@ func (c *Client) ListShares(ctx context.Context) ([]ActualShare, error) {
 	return data.Shares, nil
 }
 
-// nfsRulePayload is DSM's per-client NFS rule. Field names follow DSM 7.x; if a
-// future DSM rejects this, capture the schema via `synology status --raw-nfs`
-// from an existing export and adjust.
-type nfsRulePayload struct {
-	Client      string `json:"client"`
-	Privilege   string `json:"privilege"` // "rw" | "ro"
-	Squash      string `json:"squash"`    // "root_squash" | "all_squash" | "no_mapping"
-	Security    string `json:"security"`  // "sys"
-	EnableAsync bool   `json:"enable_async"`
-	AllowSubdir bool   `json:"is_allow_subfolder"`
-	NonPrivPort bool   `json:"is_allow_nonprivileged_port"` // inverse of "secure"
+// DSMNFSRule is one NFS client rule as stored by DSM. Schema confirmed live
+// against SYNO.Core.FileServ.NFS.SharePrivilege (load/save, v1).
+type DSMNFSRule struct {
+	Client     string `json:"client"`
+	Privilege  string `json:"privilege"`   // "rw" | "ro"
+	RootSquash string `json:"root_squash"` // "root" | "all" | "no"
+	Async      bool   `json:"async"`
+	Insecure   bool   `json:"insecure"` // inverse of NFSRule.secure
+	Crossmnt   bool   `json:"crossmnt"` // allow subfolder mounts
+	Security   struct {
+		Sys               bool `json:"sys"`
+		Kerberos          bool `json:"kerberos"`
+		KerberosIntegrity bool `json:"kerberos_integrity"`
+		KerberosPrivacy   bool `json:"kerberos_privacy"`
+	} `json:"security_flavor"`
 }
 
-func (r NFSRule) toPayload() nfsRulePayload {
+const nfsPrivAPI = "SYNO.Core.FileServ.NFS.SharePrivilege"
+
+// LoadNFSRules returns the NFS rules for a share (nil if NFS isn't configured).
+func (c *Client) LoadNFSRules(ctx context.Context, shareName string) ([]DSMNFSRule, error) {
+	q := url.Values{"share_name": {shareName}, "clear": {"false"}}
+	raw, err := c.get(ctx, nfsPrivAPI, "load", 1, q)
+	if err != nil {
+		return nil, fmt.Errorf("load NFS rules for %q: %w", shareName, err)
+	}
+	var data struct {
+		Rule []DSMNFSRule `json:"rule"`
+	}
+	if err := unmarshalData(raw, &data); err != nil {
+		return nil, fmt.Errorf("decode NFS rules for %q: %w", shareName, err)
+	}
+	return data.Rule, nil
+}
+
+// SaveNFSRules sets the NFS rule list on a share (the declared set replaces
+// what's there). Destructive → caller gates on --apply. Confirmed via a no-op
+// round-trip; rules round-trip identically.
+func (c *Client) SaveNFSRules(ctx context.Context, shareName string, rules []DSMNFSRule) error {
+	b, err := json.Marshal(rules)
+	if err != nil {
+		return err
+	}
+	q := url.Values{"share_name": {shareName}, "clear": {"false"}, "rule": {string(b)}}
+	if _, err := c.get(ctx, nfsPrivAPI, "save", 1, q); err != nil {
+		return fmt.Errorf("save NFS rules on %q: %w", shareName, err)
+	}
+	return nil
+}
+
+// toDSM maps a declared NFSRule to the DSM schema. Fields not exposed in Nix get
+// sensible defaults (crossmnt on, sys security).
+func (r NFSRule) toDSM() DSMNFSRule {
 	priv := strings.ToLower(r.Access)
 	if priv != "ro" {
 		priv = "rw"
 	}
-	sq := r.Squash
+	sq := map[string]string{"root_squash": "root", "all_squash": "all", "no_mapping": "no"}[r.Squash]
 	if sq == "" {
-		sq = "root_squash"
+		sq = "root"
 	}
-	return nfsRulePayload{
-		Client:      r.Client,
-		Privilege:   priv,
-		Squash:      sq,
-		Security:    "sys",
-		EnableAsync: r.Async,
-		AllowSubdir: true,
-		NonPrivPort: !r.Secure,
+	d := DSMNFSRule{
+		Client:     r.Client,
+		Privilege:  priv,
+		RootSquash: sq,
+		Async:      r.Async,
+		Insecure:   !r.Secure,
+		Crossmnt:   true,
 	}
+	d.Security.Sys = true
+	return d
 }
 
-// SetNFSRules sets the NFS rule list on an existing share.
-//
-// NOTE: live probing showed per-share NFS rules are NOT under SYNO.Core.Share
-// (it returns only share metadata). They live under the internal
-// SYNO.Core.FileServ.NFS.SharePrivilege API (method "load"/set), whose exact
-// params we haven't pinned yet (returns 2301). Until then, configure NFS share
-// rules via the generic escape hatch (nixfleet.synology.settings) once the
-// SharePrivilege params are confirmed, or set them in the DSM UI. This call is
-// left as the typed target and will be repointed at SharePrivilege.
-func (c *Client) SetNFSRules(ctx context.Context, share string, rules []NFSRule) error {
-	payload := make([]nfsRulePayload, 0, len(rules))
-	for _, r := range rules {
-		payload = append(payload, r.toPayload())
+// key is a stable comparison key for a rule (ignores ordering).
+func (d DSMNFSRule) key() string {
+	return fmt.Sprintf("%s|%s|%s|%t|%t|%t|%t", d.Client, d.Privilege, d.RootSquash, d.Async, d.Insecure, d.Crossmnt, d.Security.Sys)
+}
+
+// NFSRulesMatch reports whether the actual DSM rules already equal the declared
+// set (order-insensitive on the fields nixfleet manages).
+func NFSRulesMatch(declared []NFSRule, actual []DSMNFSRule) bool {
+	if len(declared) != len(actual) {
+		return false
 	}
-	b, err := json.Marshal(payload)
-	if err != nil {
-		return err
+	want := make([]string, 0, len(declared))
+	for _, r := range declared {
+		want = append(want, r.toDSM().key())
 	}
-	q := url.Values{
-		"name":     {share},
-		"nfs_rule": {string(b)},
+	got := make([]string, 0, len(actual))
+	for _, a := range actual {
+		// normalise: only the fields we manage participate in the key
+		na := a
+		na.Security = struct {
+			Sys               bool `json:"sys"`
+			Kerberos          bool `json:"kerberos"`
+			KerberosIntegrity bool `json:"kerberos_integrity"`
+			KerberosPrivacy   bool `json:"kerberos_privacy"`
+		}{Sys: a.Security.Sys}
+		got = append(got, na.key())
 	}
-	if _, err := c.get(ctx, "SYNO.Core.Share", "set", 1, q); err != nil {
-		return fmt.Errorf("set NFS rules on %q: %w", share, err)
+	sort.Strings(want)
+	sort.Strings(got)
+	for i := range want {
+		if want[i] != got[i] {
+			return false
+		}
 	}
-	return nil
+	return true
 }

--- a/cmd/nixfleet/internal/synology/nfs.go
+++ b/cmd/nixfleet/internal/synology/nfs.go
@@ -1,0 +1,97 @@
+package synology
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"strings"
+)
+
+// ActualShare is a shared folder as reported by DSM, including its NFS rules.
+type ActualShare struct {
+	Name     string          `json:"name"`
+	VolPath  string          `json:"vol_path"` // e.g. /volume1
+	NFSRules json.RawMessage `json:"nfs_rule"` // raw; schema varies by DSM version
+}
+
+// HasNFS reports whether the share has any NFS rules configured.
+func (s ActualShare) HasNFS() bool {
+	t := strings.TrimSpace(string(s.NFSRules))
+	return t != "" && t != "null" && t != "[]"
+}
+
+// ListShares returns all shared folders with their NFS rules.
+func (c *Client) ListShares(ctx context.Context) ([]ActualShare, error) {
+	q := url.Values{
+		// request the nfs_rule + volume info in the listing
+		"additional": {`["nfs_rule","vol_path"]`},
+	}
+	raw, err := c.get(ctx, "SYNO.Core.Share", "list", 1, q)
+	if err != nil {
+		return nil, fmt.Errorf("list shares: %w", err)
+	}
+	var data struct {
+		Shares []ActualShare `json:"shares"`
+	}
+	if err := unmarshalData(raw, &data); err != nil {
+		return nil, fmt.Errorf("decode share list: %w", err)
+	}
+	return data.Shares, nil
+}
+
+// nfsRulePayload is DSM's per-client NFS rule. Field names follow DSM 7.x; if a
+// future DSM rejects this, capture the schema via `synology status --raw-nfs`
+// from an existing export and adjust.
+type nfsRulePayload struct {
+	Client      string `json:"client"`
+	Privilege   string `json:"privilege"` // "rw" | "ro"
+	Squash      string `json:"squash"`    // "root_squash" | "all_squash" | "no_mapping"
+	Security    string `json:"security"`  // "sys"
+	EnableAsync bool   `json:"enable_async"`
+	AllowSubdir bool   `json:"is_allow_subfolder"`
+	NonPrivPort bool   `json:"is_allow_nonprivileged_port"` // inverse of "secure"
+}
+
+func (r NFSRule) toPayload() nfsRulePayload {
+	priv := strings.ToLower(r.Access)
+	if priv != "ro" {
+		priv = "rw"
+	}
+	sq := r.Squash
+	if sq == "" {
+		sq = "root_squash"
+	}
+	return nfsRulePayload{
+		Client:      r.Client,
+		Privilege:   priv,
+		Squash:      sq,
+		Security:    "sys",
+		EnableAsync: r.Async,
+		AllowSubdir: true,
+		NonPrivPort: !r.Secure,
+	}
+}
+
+// SetNFSRules sets the NFS rule list on an existing share (idempotent — the
+// declared rule set replaces what's there). Destructive enough to require
+// --apply. The share itself must already exist (we don't auto-create folders
+// in this slice).
+func (c *Client) SetNFSRules(ctx context.Context, share string, rules []NFSRule) error {
+	payload := make([]nfsRulePayload, 0, len(rules))
+	for _, r := range rules {
+		payload = append(payload, r.toPayload())
+	}
+	b, err := json.Marshal(payload)
+	if err != nil {
+		return err
+	}
+	q := url.Values{
+		"name":     {share},
+		"nfs_rule": {string(b)},
+	}
+	if _, err := c.get(ctx, "SYNO.Core.Share", "set", 1, q); err != nil {
+		return fmt.Errorf("set NFS rules on %q: %w", share, err)
+	}
+	return nil
+}

--- a/cmd/nixfleet/internal/synology/nfs.go
+++ b/cmd/nixfleet/internal/synology/nfs.go
@@ -73,10 +73,15 @@ func (r NFSRule) toPayload() nfsRulePayload {
 	}
 }
 
-// SetNFSRules sets the NFS rule list on an existing share (idempotent — the
-// declared rule set replaces what's there). Destructive enough to require
-// --apply. The share itself must already exist (we don't auto-create folders
-// in this slice).
+// SetNFSRules sets the NFS rule list on an existing share.
+//
+// NOTE: live probing showed per-share NFS rules are NOT under SYNO.Core.Share
+// (it returns only share metadata). They live under the internal
+// SYNO.Core.FileServ.NFS.SharePrivilege API (method "load"/set), whose exact
+// params we haven't pinned yet (returns 2301). Until then, configure NFS share
+// rules via the generic escape hatch (nixfleet.synology.settings) once the
+// SharePrivilege params are confirmed, or set them in the DSM UI. This call is
+// left as the typed target and will be repointed at SharePrivilege.
 func (c *Client) SetNFSRules(ctx context.Context, share string, rules []NFSRule) error {
 	payload := make([]nfsRulePayload, 0, len(rules))
 	for _, r := range rules {

--- a/cmd/nixfleet/internal/synology/reconcile.go
+++ b/cmd/nixfleet/internal/synology/reconcile.go
@@ -76,10 +76,16 @@ func ComputePlan(ctx context.Context, c *Client, cfg *Config) (*Plan, error) {
 		shareSet[s.Name] = true
 	}
 	for _, e := range cfg.NFSExports {
-		if shareSet[e.Name] {
-			p.NFSSet = append(p.NFSSet, e)
-		} else {
+		if !shareSet[e.Name] {
 			p.NFSNoShare = append(p.NFSNoShare, e)
+			continue
+		}
+		actual, err := c.LoadNFSRules(ctx, e.Name)
+		if err != nil {
+			return nil, err
+		}
+		if !NFSRulesMatch(e.Rules, actual) {
+			p.NFSSet = append(p.NFSSet, e) // drift → rules will be (re)written
 		}
 	}
 
@@ -126,7 +132,11 @@ func (p *Plan) Apply(ctx context.Context, c *Client, opts ApplyOpts) *ApplyResul
 		}
 	}
 	for _, e := range p.NFSSet {
-		if err := c.SetNFSRules(ctx, e.Name, e.Rules); err != nil {
+		rules := make([]DSMNFSRule, 0, len(e.Rules))
+		for _, rule := range e.Rules {
+			rules = append(rules, rule.toDSM())
+		}
+		if err := c.SaveNFSRules(ctx, e.Name, rules); err != nil {
 			r.Errors = append(r.Errors, fmt.Sprintf("set NFS %s: %v", e.Name, err))
 			continue
 		}

--- a/cmd/nixfleet/internal/synology/reconcile.go
+++ b/cmd/nixfleet/internal/synology/reconcile.go
@@ -1,0 +1,180 @@
+package synology
+
+import (
+	"context"
+	"fmt"
+	"strings"
+)
+
+// Plan is the diff between declared (Nix) and actual (DSM) state.
+type Plan struct {
+	LUNCreate  []LUN       // declared, missing on the NAS
+	LUNGrow    []LUNResize // declared larger than actual (online grow)
+	LUNShrink  []LUNResize // declared smaller — refused (reported only)
+	LUNExtra   []ActualLUN // on the NAS, not declared (prune candidates)
+	NFSSet     []NFSExport // declared exports whose share exists → rules will be set
+	NFSNoShare []NFSExport // declared export but no matching share (manual create needed)
+}
+
+// LUNResize captures a size delta for an existing LUN.
+type LUNResize struct {
+	Declared  LUN
+	Actual    ActualLUN
+	WantBytes int64
+}
+
+// Empty reports whether the plan would change anything.
+func (p Plan) Empty() bool {
+	return len(p.LUNCreate) == 0 && len(p.LUNGrow) == 0 && len(p.NFSSet) == 0
+}
+
+// ComputePlan diffs the declared config against live DSM state.
+func ComputePlan(ctx context.Context, c *Client, cfg *Config) (*Plan, error) {
+	actualLUNs, err := c.ListLUNs(ctx)
+	if err != nil {
+		return nil, err
+	}
+	byName := make(map[string]ActualLUN, len(actualLUNs))
+	declared := make(map[string]bool, len(cfg.ISCSILUNs))
+	for _, a := range actualLUNs {
+		byName[a.Name] = a
+	}
+
+	p := &Plan{}
+	for _, l := range cfg.ISCSILUNs {
+		declared[l.Name] = true
+		want, err := l.SizeBytes()
+		if err != nil {
+			return nil, fmt.Errorf("LUN %q: %w", l.Name, err)
+		}
+		a, ok := byName[l.Name]
+		if !ok {
+			p.LUNCreate = append(p.LUNCreate, l)
+			continue
+		}
+		switch {
+		case want > a.Size:
+			p.LUNGrow = append(p.LUNGrow, LUNResize{Declared: l, Actual: a, WantBytes: want})
+		case want < a.Size:
+			p.LUNShrink = append(p.LUNShrink, LUNResize{Declared: l, Actual: a, WantBytes: want})
+		}
+	}
+	for _, a := range actualLUNs {
+		if !declared[a.Name] {
+			p.LUNExtra = append(p.LUNExtra, a)
+		}
+	}
+
+	// NFS exports: a declared export needs an existing share to attach rules to.
+	shares, err := c.ListShares(ctx)
+	if err != nil {
+		return nil, err
+	}
+	shareSet := make(map[string]bool, len(shares))
+	for _, s := range shares {
+		shareSet[s.Name] = true
+	}
+	for _, e := range cfg.NFSExports {
+		if shareSet[e.Name] {
+			p.NFSSet = append(p.NFSSet, e)
+		} else {
+			p.NFSNoShare = append(p.NFSNoShare, e)
+		}
+	}
+	return p, nil
+}
+
+// ApplyOpts gates the destructive parts of a reconcile.
+type ApplyOpts struct {
+	Prune       bool // delete LUNs that exist but aren't declared
+	AllowResize bool // online-grow LUNs that are declared larger
+}
+
+// ApplyResult records what Apply did.
+type ApplyResult struct {
+	Created []string
+	Grown   []string
+	Deleted []string
+	NFSSet  []string
+	Errors  []string
+}
+
+// Apply executes the plan. Caller is responsible for confirming intent (the CLI
+// requires --apply). Create + NFS-set always run; delete/grow are opt-in.
+func (p *Plan) Apply(ctx context.Context, c *Client, opts ApplyOpts) *ApplyResult {
+	r := &ApplyResult{}
+	for _, l := range p.LUNCreate {
+		if _, err := c.CreateLUN(ctx, l); err != nil {
+			r.Errors = append(r.Errors, fmt.Sprintf("create LUN %s: %v", l.Name, err))
+			continue
+		}
+		r.Created = append(r.Created, l.Name)
+	}
+	if opts.AllowResize {
+		for _, g := range p.LUNGrow {
+			if err := c.GrowLUN(ctx, g.Actual.UUID, g.WantBytes); err != nil {
+				r.Errors = append(r.Errors, fmt.Sprintf("grow LUN %s: %v", g.Declared.Name, err))
+				continue
+			}
+			r.Grown = append(r.Grown, g.Declared.Name)
+		}
+	}
+	for _, e := range p.NFSSet {
+		if err := c.SetNFSRules(ctx, e.Name, e.Rules); err != nil {
+			r.Errors = append(r.Errors, fmt.Sprintf("set NFS %s: %v", e.Name, err))
+			continue
+		}
+		r.NFSSet = append(r.NFSSet, e.Name)
+	}
+	if opts.Prune {
+		for _, a := range p.LUNExtra {
+			if err := c.DeleteLUN(ctx, a.UUID); err != nil {
+				r.Errors = append(r.Errors, fmt.Sprintf("delete LUN %s: %v", a.Name, err))
+				continue
+			}
+			r.Deleted = append(r.Deleted, a.Name)
+		}
+	}
+	return r
+}
+
+// Render returns a human-readable summary of the plan.
+func (p Plan) Render() string {
+	var b strings.Builder
+	line := func(sym, msg string) { fmt.Fprintf(&b, "  %s %s\n", sym, msg) }
+	for _, l := range p.LUNCreate {
+		line("+", fmt.Sprintf("create LUN %q (%s, %s on %s)", l.Name, l.Size, l.dsmType(), l.Location))
+	}
+	for _, g := range p.LUNGrow {
+		line("~", fmt.Sprintf("grow LUN %q %s → %s (needs --allow-resize)", g.Declared.Name, HumanBytes(g.Actual.Size), g.Declared.Size))
+	}
+	for _, s := range p.LUNShrink {
+		line("!", fmt.Sprintf("LUN %q declared smaller (%s < %s) — REFUSED (no shrink)", s.Declared.Name, s.Declared.Size, HumanBytes(s.Actual.Size)))
+	}
+	for _, a := range p.LUNExtra {
+		line("-", fmt.Sprintf("LUN %q exists but is not declared (delete only with --prune)", a.Name))
+	}
+	for _, e := range p.NFSSet {
+		line("+", fmt.Sprintf("set %d NFS rule(s) on share %q", len(e.Rules), e.Name))
+	}
+	for _, e := range p.NFSNoShare {
+		line("!", fmt.Sprintf("NFS export %q has no matching share — create the shared folder first", e.Name))
+	}
+	if b.Len() == 0 {
+		return "  (no changes — NAS matches declared state)\n"
+	}
+	return b.String()
+}
+
+func HumanBytes(n int64) string {
+	const u = 1024
+	if n < u {
+		return fmt.Sprintf("%dB", n)
+	}
+	div, exp := int64(u), 0
+	for v := n / u; v >= u; v /= u {
+		div *= u
+		exp++
+	}
+	return fmt.Sprintf("%.0f%c", float64(n)/float64(div), "KMGT"[exp])
+}

--- a/cmd/nixfleet/internal/synology/reconcile.go
+++ b/cmd/nixfleet/internal/synology/reconcile.go
@@ -14,6 +14,7 @@ type Plan struct {
 	LUNExtra   []ActualLUN // on the NAS, not declared (prune candidates)
 	NFSSet     []NFSExport // declared exports whose share exists → rules will be set
 	NFSNoShare []NFSExport // declared export but no matching share (manual create needed)
+	Settings   []Setting   // generic DSM settings to apply (idempotent set calls)
 }
 
 // LUNResize captures a size delta for an existing LUN.
@@ -25,7 +26,7 @@ type LUNResize struct {
 
 // Empty reports whether the plan would change anything.
 func (p Plan) Empty() bool {
-	return len(p.LUNCreate) == 0 && len(p.LUNGrow) == 0 && len(p.NFSSet) == 0
+	return len(p.LUNCreate) == 0 && len(p.LUNGrow) == 0 && len(p.NFSSet) == 0 && len(p.Settings) == 0
 }
 
 // ComputePlan diffs the declared config against live DSM state.
@@ -81,6 +82,10 @@ func ComputePlan(ctx context.Context, c *Client, cfg *Config) (*Plan, error) {
 			p.NFSNoShare = append(p.NFSNoShare, e)
 		}
 	}
+
+	// Generic settings are applied as declared (DSM set calls are idempotent;
+	// we don't diff them since each api's get-shape differs).
+	p.Settings = cfg.Settings
 	return p, nil
 }
 
@@ -92,11 +97,12 @@ type ApplyOpts struct {
 
 // ApplyResult records what Apply did.
 type ApplyResult struct {
-	Created []string
-	Grown   []string
-	Deleted []string
-	NFSSet  []string
-	Errors  []string
+	Created  []string
+	Grown    []string
+	Deleted  []string
+	NFSSet   []string
+	Settings []string
+	Errors   []string
 }
 
 // Apply executes the plan. Caller is responsible for confirming intent (the CLI
@@ -125,6 +131,13 @@ func (p *Plan) Apply(ctx context.Context, c *Client, opts ApplyOpts) *ApplyResul
 			continue
 		}
 		r.NFSSet = append(r.NFSSet, e.Name)
+	}
+	for _, s := range p.Settings {
+		if err := c.ApplySetting(ctx, s); err != nil {
+			r.Errors = append(r.Errors, err.Error())
+			continue
+		}
+		r.Settings = append(r.Settings, s.String())
 	}
 	if opts.Prune {
 		for _, a := range p.LUNExtra {
@@ -159,6 +172,9 @@ func (p Plan) Render() string {
 	}
 	for _, e := range p.NFSNoShare {
 		line("!", fmt.Sprintf("NFS export %q has no matching share — create the shared folder first", e.Name))
+	}
+	for _, s := range p.Settings {
+		line("+", fmt.Sprintf("apply setting %s", s))
 	}
 	if b.Len() == 0 {
 		return "  (no changes — NAS matches declared state)\n"

--- a/cmd/nixfleet/internal/synology/settings.go
+++ b/cmd/nixfleet/internal/synology/settings.go
@@ -1,0 +1,85 @@
+package synology
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"sort"
+	"strings"
+)
+
+// Setting is a declarative DSM API call applied during reconcile — the generic
+// escape hatch for configuring *any* DSM setting not yet covered by a typed
+// option (mirrors the Terraform provider's generic API resource). The whole DSM
+// settings surface (SYNO.Core.FileServ.NFS/SMB, SYNO.Core.Network, .System,
+// .Service, .SNMP, …) follows the same entry.cgi get/set shape, so one wrapper
+// reaches all of it.
+//
+//	nixfleet.synology.settings = [{
+//	  api = "SYNO.Core.FileServ.NFS"; method = "set"; version = 1;
+//	  params = { enable_nfs = "true"; enable_nfs_v4 = "true"; };
+//	}];
+type Setting struct {
+	API     string            `json:"api"`
+	Method  string            `json:"method"`
+	Version int               `json:"version"`
+	Params  map[string]string `json:"params"`
+}
+
+func (s Setting) version() int {
+	if s.Version <= 0 {
+		return 1
+	}
+	return s.Version
+}
+
+func (s Setting) values() url.Values {
+	v := url.Values{}
+	keys := make([]string, 0, len(s.Params))
+	for k := range s.Params {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys) // stable ordering for logging/idempotency
+	for _, k := range keys {
+		v.Set(k, s.Params[k])
+	}
+	return v
+}
+
+// String renders a setting for plans/logs (params keys only — values may be
+// sensitive and aren't printed).
+func (s Setting) String() string {
+	keys := make([]string, 0, len(s.Params))
+	for k := range s.Params {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return fmt.Sprintf("%s.%s v%d {%s}", s.API, s.Method, s.version(), strings.Join(keys, ","))
+}
+
+// Call issues a generic DSM API call and returns the raw data payload. Works for
+// reads (method=get/list/load) and writes (method=set) alike.
+func (c *Client) Call(ctx context.Context, api, method string, version int, params map[string]string) (json.RawMessage, error) {
+	if version <= 0 {
+		version = 1
+	}
+	extra := url.Values{}
+	for k, v := range params {
+		extra.Set(k, v)
+	}
+	raw, err := c.get(ctx, api, method, version, extra)
+	if err != nil {
+		return nil, fmt.Errorf("%s.%s v%d: %w", api, method, version, err)
+	}
+	return raw, nil
+}
+
+// ApplySetting issues a declared setting (an idempotent write). DSM set calls
+// are idempotent — re-applying the same params is a no-op.
+func (c *Client) ApplySetting(ctx context.Context, s Setting) error {
+	if _, err := c.get(ctx, s.API, s.Method, s.version(), s.values()); err != nil {
+		return fmt.Errorf("apply %s: %w", s, err)
+	}
+	return nil
+}

--- a/cmd/nixfleet/internal/synology/synology_test.go
+++ b/cmd/nixfleet/internal/synology/synology_test.go
@@ -1,0 +1,110 @@
+package synology
+
+import "testing"
+
+func TestParseSize(t *testing.T) {
+	cases := []struct {
+		in      string
+		want    int64
+		wantErr bool
+	}{
+		{"500G", 500 << 30, false},
+		{"1T", 1 << 40, false},
+		{"512M", 512 << 20, false},
+		{"10737418240", 10737418240, false},
+		{"2GB", 2 << 30, false}, // GB suffix tolerated
+		{"1.5G", int64(1.5 * float64(1<<30)), false},
+		{"", 0, true},
+		{"banana", 0, true},
+	}
+	for _, c := range cases {
+		got, err := parseSize(c.in)
+		if c.wantErr {
+			if err == nil {
+				t.Errorf("parseSize(%q): expected error, got %d", c.in, got)
+			}
+			continue
+		}
+		if err != nil {
+			t.Errorf("parseSize(%q): unexpected error %v", c.in, err)
+		}
+		if got != c.want {
+			t.Errorf("parseSize(%q) = %d, want %d", c.in, got, c.want)
+		}
+	}
+}
+
+func TestDSMCreateType(t *testing.T) {
+	cases := map[string]string{"THIN": "BLUN", "": "BLUN", "FILE": "FILE", "ADV": "ADV"}
+	for in, want := range cases {
+		if got := dsmCreateType(LUN{Type: in}); got != want {
+			t.Errorf("dsmCreateType(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestNFSRuleToDSM(t *testing.T) {
+	r := NFSRule{Client: "192.168.3.0/24", Access: "ro", Squash: "all_squash", Secure: true, Async: false}
+	d := r.toDSM()
+	if d.Client != "192.168.3.0/24" || d.Privilege != "ro" || d.RootSquash != "all" {
+		t.Errorf("mapping mismatch: %+v", d)
+	}
+	if d.Insecure { // secure=true => insecure=false
+		t.Errorf("secure=true should map to insecure=false, got insecure=true")
+	}
+	if !d.Security.Sys || !d.Crossmnt {
+		t.Errorf("expected sys+crossmnt defaults, got %+v", d)
+	}
+
+	// defaults: empty access -> rw, empty squash -> root, secure default false -> insecure
+	def := NFSRule{Client: "*"}.toDSM()
+	if def.Privilege != "rw" || def.RootSquash != "root" || !def.Insecure {
+		t.Errorf("default mapping wrong: %+v", def)
+	}
+}
+
+func TestNFSRulesMatch(t *testing.T) {
+	declared := []NFSRule{{Client: "*", Access: "rw", Squash: "root_squash", Secure: false, Async: true}}
+	// actual that equals the declared rule (the live k0s-gti shape)
+	actual := []DSMNFSRule{{Client: "*", Privilege: "rw", RootSquash: "root", Async: true, Insecure: true, Crossmnt: true}}
+	actual[0].Security.Sys = true
+	if !NFSRulesMatch(declared, actual) {
+		t.Errorf("expected match for equivalent rule sets")
+	}
+
+	// drift: different client
+	drift := []DSMNFSRule{{Client: "10.0.0.0/8", Privilege: "rw", RootSquash: "root", Async: true, Insecure: true, Crossmnt: true}}
+	drift[0].Security.Sys = true
+	if NFSRulesMatch(declared, drift) {
+		t.Errorf("expected mismatch on differing client")
+	}
+
+	// drift: different count
+	if NFSRulesMatch(declared, nil) {
+		t.Errorf("expected mismatch on empty actual")
+	}
+}
+
+func TestSettingValues(t *testing.T) {
+	s := Setting{API: "SYNO.Core.FileServ.NFS", Method: "set", Params: map[string]string{"enable_nfs": "true", "read_size": "8192"}}
+	if s.version() != 1 {
+		t.Errorf("default version should be 1, got %d", s.version())
+	}
+	v := s.values()
+	if v.Get("enable_nfs") != "true" || v.Get("read_size") != "8192" {
+		t.Errorf("values mismatch: %v", v)
+	}
+	// String must not leak param values (keys only)
+	if got := s.String(); got == "" || containsValue(got, "8192") {
+		t.Errorf("String() should list keys without values, got %q", got)
+	}
+}
+
+func containsValue(s, v string) bool {
+	for i := 0; i+len(v) <= len(s); i++ {
+		if s[i:i+len(v)] == v {
+			return true
+		}
+	}
+	return false
+}

--- a/cmd/nixfleet/main.go
+++ b/cmd/nixfleet/main.go
@@ -115,6 +115,7 @@ It provides Ansible-like UX for:
 	cmd.AddCommand(spireCmd())
 	cmd.AddCommand(juicefsCmd())
 	cmd.AddCommand(stateCmd())
+	cmd.AddCommand(synologyCmd())
 
 	return cmd
 }

--- a/cmd/nixfleet/synology_cmd.go
+++ b/cmd/nixfleet/synology_cmd.go
@@ -202,10 +202,14 @@ func synologyStatusCmd() *cobra.Command {
 			fmt.Printf("\nShares (%d):\n", len(shares))
 			for _, s := range shares {
 				nfs := "—"
-				if s.HasNFS() {
-					nfs = "NFS"
+				if rules, err := cl.LoadNFSRules(ctx, s.Name); err == nil && len(rules) > 0 {
+					clients := make([]string, 0, len(rules))
+					for _, r := range rules {
+						clients = append(clients, fmt.Sprintf("%s(%s)", r.Client, r.Privilege))
+					}
+					nfs = "NFS: " + strings.Join(clients, ", ")
 				}
-				fmt.Printf("  %-28s %-12s %s\n", s.Name, s.VolPath, nfs)
+				fmt.Printf("  %-22s %-10s %s\n", s.Name, s.VolPath, nfs)
 			}
 			return nil
 		},

--- a/cmd/nixfleet/synology_cmd.go
+++ b/cmd/nixfleet/synology_cmd.go
@@ -1,0 +1,223 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+
+	"github.com/nixfleet/nixfleet/internal/nix"
+	"github.com/nixfleet/nixfleet/internal/synology"
+	"github.com/spf13/cobra"
+)
+
+func synologyCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "synology",
+		Short: "Manage a Synology NAS via the DSM API (Model B)",
+		Long: `Declaratively manage a Synology NAS over the DSM Web API.
+
+Desired state is declared in Nix under 'nixfleet.synology' (iSCSI LUNs and NFS
+exports in this slice) and reconciled here — no SSH/closure involved. The DSM
+password is sourced out-of-band (never from Nix):
+
+  --password-command "op read 'op://Personal Agents/nas botuser/confirmpassword'"
+  or  $SYNOLOGY_PASSWORD
+
+Examples:
+  nixfleet synology status znas
+  nixfleet synology reconcile znas               # dry-run (default)
+  nixfleet synology reconcile znas --apply       # create missing LUNs + set NFS
+  nixfleet synology reconcile znas --apply --allow-resize --prune`,
+	}
+	cmd.PersistentFlags().String("password-command", "",
+		"Command whose stdout is the DSM password (falls back to $SYNOLOGY_PASSWORD)")
+	cmd.AddCommand(synologyStatusCmd())
+	cmd.AddCommand(synologyReconcileCmd())
+	return cmd
+}
+
+// synologyHostArg resolves the host name (a nixfleetConfigurations key) from a
+// positional arg or the global -H flag.
+func synologyHostArg(args []string) (string, error) {
+	if len(args) > 0 && args[0] != "" {
+		return args[0], nil
+	}
+	if targetHost != "" {
+		return targetHost, nil
+	}
+	return "", fmt.Errorf("specify a host: nixfleet synology <status|reconcile> <host> (or -H)")
+}
+
+// synologyLoadConfig evaluates the declarative DSM spec for a host.
+func synologyLoadConfig(ctx context.Context, host string) (*synology.Config, error) {
+	flake, err := nix.ResolveFlakePath(flakePath)
+	if err != nil {
+		return nil, err
+	}
+	ev, err := nix.NewEvaluator(flake)
+	if err != nil {
+		return nil, err
+	}
+	raw, err := ev.EvalAttrJSON(ctx, fmt.Sprintf("nixfleetConfigurations.%s.synology", host))
+	if err != nil {
+		return nil, err
+	}
+	var cfg synology.Config
+	if err := json.Unmarshal(raw, &cfg); err != nil {
+		return nil, fmt.Errorf("decode synology config for %s: %w", host, err)
+	}
+	if !cfg.Enable {
+		return nil, fmt.Errorf("host %q does not set nixfleet.synology.enable = true", host)
+	}
+	if cfg.Host == "" {
+		return nil, fmt.Errorf("host %q: nixfleet.synology.host is empty", host)
+	}
+	return &cfg, nil
+}
+
+// synologyPassword resolves the DSM password without ever logging it.
+func synologyPassword(cmd *cobra.Command) (string, error) {
+	if pc, _ := cmd.Flags().GetString("password-command"); pc != "" {
+		out, err := exec.Command("sh", "-c", pc).Output()
+		if err != nil {
+			return "", fmt.Errorf("password-command failed: %w", err)
+		}
+		pw := strings.TrimSpace(string(out))
+		if pw == "" {
+			return "", fmt.Errorf("password-command produced no output")
+		}
+		return pw, nil
+	}
+	if p := os.Getenv("SYNOLOGY_PASSWORD"); p != "" {
+		return p, nil
+	}
+	return "", fmt.Errorf("no DSM password: pass --password-command or set $SYNOLOGY_PASSWORD")
+}
+
+// synologyConnect evaluates config, resolves the password, and logs in.
+func synologyConnect(ctx context.Context, cmd *cobra.Command, host string) (*synology.Client, *synology.Config, error) {
+	cfg, err := synologyLoadConfig(ctx, host)
+	if err != nil {
+		return nil, nil, err
+	}
+	pw, err := synologyPassword(cmd)
+	if err != nil {
+		return nil, nil, err
+	}
+	cl := synology.NewClient(cfg.Host, cfg.Port, cfg.HTTPS, cfg.User, pw)
+	if err := cl.Login(ctx); err != nil {
+		return nil, nil, err
+	}
+	return cl, cfg, nil
+}
+
+func synologyStatusCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "status [host]",
+		Short: "Show live DSM state (iSCSI LUNs + NFS shares)",
+		Args:  cobra.MaximumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := cmd.Context()
+			host, err := synologyHostArg(args)
+			if err != nil {
+				return err
+			}
+			cl, cfg, err := synologyConnect(ctx, cmd, host)
+			if err != nil {
+				return err
+			}
+			defer cl.Logout(ctx)
+
+			fmt.Printf("Synology %q  (%s@%s:%d)\n\n", host, cfg.User, cfg.Host, cfg.Port)
+
+			luns, err := cl.ListLUNs(ctx)
+			if err != nil {
+				return err
+			}
+			fmt.Printf("iSCSI LUNs (%d):\n", len(luns))
+			for _, l := range luns {
+				fmt.Printf("  %-28s %-8s %-9s %s\n", l.Name, l.Type, synology.HumanBytes(l.Size), l.Location)
+			}
+
+			shares, err := cl.ListShares(ctx)
+			if err != nil {
+				return err
+			}
+			fmt.Printf("\nShares (%d):\n", len(shares))
+			for _, s := range shares {
+				nfs := "—"
+				if s.HasNFS() {
+					nfs = "NFS"
+				}
+				fmt.Printf("  %-28s %-12s %s\n", s.Name, s.VolPath, nfs)
+			}
+			return nil
+		},
+	}
+}
+
+func synologyReconcileCmd() *cobra.Command {
+	var apply, prune, allowResize bool
+	cmd := &cobra.Command{
+		Use:   "reconcile [host]",
+		Short: "Diff declared (Nix) vs actual DSM state, optionally apply",
+		Args:  cobra.MaximumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := cmd.Context()
+			host, err := synologyHostArg(args)
+			if err != nil {
+				return err
+			}
+			cl, cfg, err := synologyConnect(ctx, cmd, host)
+			if err != nil {
+				return err
+			}
+			defer cl.Logout(ctx)
+
+			plan, err := synology.ComputePlan(ctx, cl, cfg)
+			if err != nil {
+				return err
+			}
+			fmt.Printf("Reconcile plan for %q:\n%s", host, plan.Render())
+
+			nothingToApply := plan.Empty()
+			if !apply {
+				if !nothingToApply {
+					fmt.Println("\n(dry-run — re-run with --apply to make changes)")
+				}
+				return nil
+			}
+			if nothingToApply && !prune {
+				return nil
+			}
+
+			res := plan.Apply(ctx, cl, synology.ApplyOpts{Prune: prune, AllowResize: allowResize})
+			for _, n := range res.Created {
+				fmt.Printf("  created LUN %s\n", n)
+			}
+			for _, n := range res.Grown {
+				fmt.Printf("  grew LUN %s\n", n)
+			}
+			for _, n := range res.NFSSet {
+				fmt.Printf("  set NFS rules on %s\n", n)
+			}
+			for _, n := range res.Deleted {
+				fmt.Printf("  deleted LUN %s\n", n)
+			}
+			for _, e := range res.Errors {
+				fmt.Fprintf(os.Stderr, "  ERROR: %s\n", e)
+			}
+			if len(res.Errors) > 0 {
+				return fmt.Errorf("%d error(s) during reconcile", len(res.Errors))
+			}
+			return nil
+		},
+	}
+	cmd.Flags().BoolVar(&apply, "apply", false, "Make changes (default: dry-run)")
+	cmd.Flags().BoolVar(&prune, "prune", false, "Delete LUNs that exist but aren't declared (DESTRUCTIVE)")
+	cmd.Flags().BoolVar(&allowResize, "allow-resize", false, "Online-grow LUNs declared larger than actual")
+	return cmd
+}

--- a/cmd/nixfleet/synology_cmd.go
+++ b/cmd/nixfleet/synology_cmd.go
@@ -36,6 +36,59 @@ Examples:
 		"Command whose stdout is the DSM password (falls back to $SYNOLOGY_PASSWORD)")
 	cmd.AddCommand(synologyStatusCmd())
 	cmd.AddCommand(synologyReconcileCmd())
+	cmd.AddCommand(synologyGetCmd())
+	return cmd
+}
+
+// synologyGetCmd is a generic DSM API reader — useful for discovering the shape
+// of any setting before declaring it under nixfleet.synology.settings.
+func synologyGetCmd() *cobra.Command {
+	var version int
+	var params []string
+	cmd := &cobra.Command{
+		Use:   "get <host> <api> [method]",
+		Short: "Read any DSM API (e.g. SYNO.Core.FileServ.NFS get)",
+		Long: `Generic DSM API read. Examples:
+  nixfleet synology get znas SYNO.Core.FileServ.NFS get
+  nixfleet synology get znas SYNO.Core.Network get --version 2
+  nixfleet synology get znas SYNO.Core.Share list --param 'additional=["vol_path"]'`,
+		Args: cobra.RangeArgs(2, 3),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := cmd.Context()
+			host, api := args[0], args[1]
+			method := "get"
+			if len(args) == 3 {
+				method = args[2]
+			}
+			pm := map[string]string{}
+			for _, kv := range params {
+				k, v, ok := strings.Cut(kv, "=")
+				if !ok {
+					return fmt.Errorf("bad --param %q (want key=value)", kv)
+				}
+				pm[k] = v
+			}
+			cl, _, err := synologyConnect(ctx, cmd, host)
+			if err != nil {
+				return err
+			}
+			defer cl.Logout(ctx)
+			raw, err := cl.Call(ctx, api, method, version, pm)
+			if err != nil {
+				return err
+			}
+			var pretty any
+			if json.Unmarshal(raw, &pretty) == nil {
+				b, _ := json.MarshalIndent(pretty, "", "  ")
+				fmt.Println(string(b))
+			} else {
+				fmt.Println(string(raw))
+			}
+			return nil
+		},
+	}
+	cmd.Flags().IntVar(&version, "version", 1, "API version")
+	cmd.Flags().StringArrayVar(&params, "param", nil, "Query param key=value (repeatable)")
 	return cmd
 }
 

--- a/flake.nix
+++ b/flake.nix
@@ -84,6 +84,11 @@
           manifestHash = evaluated.config.nixfleet.ubuntu.manifestHash;
           hostName = evaluated.config.nixfleet.host.name;
           base = evaluated.config.nixfleet.host.base;
+
+          # Declarative Synology DSM state (Model B) — reconciled by the CLI over
+          # the DSM API. Lazy: only forced by `nix eval … .synology`, so ubuntu
+          # hosts never build it.
+          synology = evaluated.config.nixfleet.synology;
         };
 
       # Create a NixOS configuration with NixFleet modules
@@ -276,6 +281,10 @@
         };
         gtr-153 = mkNixFleetConfiguration {
           modules = [ ./hosts/gtr-153.nix ];
+        };
+        # Synology NAS — managed via the DSM API (Model B), not SSH.
+        znas = mkNixFleetConfiguration {
+          modules = [ ./hosts/znas.nix ];
         };
       };
 

--- a/hosts/znas.nix
+++ b/hosts/znas.nix
@@ -1,0 +1,48 @@
+# Synology NAS (znas, 192.168.1.67) — managed via the DSM API (Model B).
+#
+# This host is NOT deployed over SSH; `nixfleet synology reconcile znas`
+# reconciles the declared DSM state below over the DSM Web API.
+#
+# IMPORTANT: the synology-csi driver creates/deletes iSCSI LUNs DYNAMICALLY for
+# k0s PVCs. Those are NOT declared here and must never be pruned — only declare
+# static, manually-provisioned LUNs in `iscsiLuns`, and never run reconcile with
+# --prune against this NAS.
+{ ... }:
+{
+  nixfleet.host = {
+    name = "znas";
+    base = "synology";
+    addr = "192.168.1.67";
+  };
+
+  nixfleet.synology = {
+    enable = true;
+    host = "192.168.1.67";
+    port = 5001;
+    # botuser has iSCSI permission (created for synology-csi) but NOT share/NFS
+    # admin — NFS apply returns 403 until it's granted "Application Privileges →
+    # File Station/shared-folder admin" in DSM (or use an admin account). LUN
+    # read + reconcile-diff work today; `status` + dry-run `reconcile` are safe.
+    user = "botuser";
+
+    # Static iSCSI LUNs (CSI-managed dynamic LUNs are intentionally absent).
+    iscsiLuns = [ ];
+
+    # NFS exports. k0s-gti (/volume1/k0s-gti) is the cluster backup target the
+    # zfs/k0s backups write to (see modules/backup.nix). Adjust the client rule
+    # to match reality after the first `synology status`.
+    nfsExports = [
+      {
+        name = "k0s-gti";
+        rules = [
+          {
+            client = "192.168.3.0/24";
+            access = "rw";
+            squash = "root_squash";
+            secure = false;
+          }
+        ];
+      }
+    ];
+  };
+}

--- a/hosts/znas.nix
+++ b/hosts/znas.nix
@@ -29,17 +29,20 @@
     iscsiLuns = [ ];
 
     # NFS exports. k0s-gti (/volume1/k0s-gti) is the cluster backup target the
-    # zfs/k0s backups write to (see modules/backup.nix). Adjust the client rule
-    # to match reality after the first `synology status`.
+    # zfs/k0s backups write to (see modules/backup.nix). These rules MATCH the
+    # live export (client "*", verified via `synology status`), so reconcile is
+    # a no-op. TODO security: tighten client "*" to the real mount source subnet
+    # once the node→.67 source IPs are confirmed (don't break the backup mount).
     nfsExports = [
       {
         name = "k0s-gti";
         rules = [
           {
-            client = "192.168.3.0/24";
+            client = "*";
             access = "rw";
             squash = "root_squash";
             secure = false;
+            async = true;
           }
         ];
       }

--- a/modules/nixfleet/default.nix
+++ b/modules/nixfleet/default.nix
@@ -9,6 +9,7 @@
 {
   imports = [
     ./options.nix
+    ./synology.nix
     ../../backends/ubuntu/compile.nix
   ];
 

--- a/modules/nixfleet/options.nix
+++ b/modules/nixfleet/options.nix
@@ -331,8 +331,9 @@ in
         type = types.enum [
           "ubuntu"
           "nixos"
+          "synology"
         ];
-        description = "Base OS type";
+        description = "Base OS type. 'synology' hosts are managed via the DSM API (Model B), not SSH.";
       };
 
       addr = mkOption {

--- a/modules/nixfleet/synology.nix
+++ b/modules/nixfleet/synology.nix
@@ -1,0 +1,149 @@
+# NixFleet Synology (DSM-API) backend options — Model B.
+#
+# Declares desired Synology DSM state (iSCSI LUNs + NFS exports). The nixfleet
+# CLI evaluates `config.nixfleet.synology` and reconciles it over the DSM Web
+# API (see cmd/nixfleet/internal/synology). Nothing here is "built" — it's a
+# pure declarative spec, so no backend compile step is involved.
+{ lib, ... }:
+let
+  inherit (lib) mkOption types;
+
+  lunType = types.submodule {
+    options = {
+      name = mkOption {
+        type = types.str;
+        description = "iSCSI LUN name (match key against the NAS).";
+      };
+      location = mkOption {
+        type = types.str;
+        default = "/volume1";
+        description = "Volume the LUN lives on (e.g. /volume1).";
+      };
+      size = mkOption {
+        type = types.str;
+        example = "500G";
+        description = "LUN size — human form (500G, 1T) or a raw byte count.";
+      };
+      type = mkOption {
+        type = types.enum [
+          "THIN"
+          "FILE"
+          "ADV"
+        ];
+        default = "THIN";
+        description = "LUN type. THIN maps to btrfs block-level (BLUN) on create.";
+      };
+      thinProvisioned = mkOption {
+        type = types.bool;
+        default = true;
+        description = "Thin-provision the LUN.";
+      };
+      description = mkOption {
+        type = types.str;
+        default = "";
+        description = "Free-text LUN description.";
+      };
+      canSnapshot = mkOption {
+        type = types.bool;
+        default = true;
+        description = "Enable snapshot capability on the LUN.";
+      };
+    };
+  };
+
+  nfsRuleType = types.submodule {
+    options = {
+      client = mkOption {
+        type = types.str;
+        example = "192.168.3.0/24";
+        description = "Allowed client: IP, CIDR, hostname, or '*'.";
+      };
+      access = mkOption {
+        type = types.enum [
+          "rw"
+          "ro"
+        ];
+        default = "rw";
+        description = "Read-write or read-only.";
+      };
+      squash = mkOption {
+        type = types.enum [
+          "root_squash"
+          "all_squash"
+          "no_mapping"
+        ];
+        default = "root_squash";
+        description = "UID/GID mapping policy.";
+      };
+      secure = mkOption {
+        type = types.bool;
+        default = true;
+        description = "Require connections from a privileged source port (<1024).";
+      };
+      async = mkOption {
+        type = types.bool;
+        default = false;
+        description = "Allow asynchronous writes (faster, less durable).";
+      };
+    };
+  };
+
+  nfsExportType = types.submodule {
+    options = {
+      name = mkOption {
+        type = types.str;
+        description = "Shared-folder name to attach NFS rules to (must already exist).";
+      };
+      path = mkOption {
+        type = types.str;
+        default = "";
+        description = "Optional explicit path; defaults to <volume>/<name>.";
+      };
+      rules = mkOption {
+        type = types.listOf nfsRuleType;
+        default = [ ];
+        description = "NFS client access rules for this share.";
+      };
+    };
+  };
+in
+{
+  options.nixfleet.synology = {
+    enable = mkOption {
+      type = types.bool;
+      default = false;
+      description = "Manage this host as a Synology NAS via the DSM API (Model B).";
+    };
+    host = mkOption {
+      type = types.str;
+      default = "";
+      example = "192.168.1.67";
+      description = "DSM host/IP.";
+    };
+    port = mkOption {
+      type = types.int;
+      default = 5001;
+      description = "DSM API port (5001 https / 5000 http).";
+    };
+    https = mkOption {
+      type = types.bool;
+      default = true;
+      description = "Use HTTPS (DSM self-signed cert is accepted).";
+    };
+    user = mkOption {
+      type = types.str;
+      default = "botuser";
+      description = "DSM account for API calls. Password is sourced out-of-band (never in Nix).";
+    };
+    iscsiLuns = mkOption {
+      type = types.listOf lunType;
+      default = [ ];
+      description = "Declared iSCSI LUNs (e.g. the k0s CSI backing store).";
+    };
+    nfsExports = mkOption {
+      type = types.listOf nfsExportType;
+      default = [ ];
+      description = "Declared NFS exports (e.g. the k0s/backup share).";
+    };
+  };
+}

--- a/modules/nixfleet/synology.nix
+++ b/modules/nixfleet/synology.nix
@@ -106,6 +106,31 @@ let
       };
     };
   };
+
+  settingType = types.submodule {
+    options = {
+      api = mkOption {
+        type = types.str;
+        example = "SYNO.Core.FileServ.NFS";
+        description = "DSM API name.";
+      };
+      method = mkOption {
+        type = types.str;
+        default = "set";
+        description = "API method (usually 'set').";
+      };
+      version = mkOption {
+        type = types.int;
+        default = 1;
+        description = "API version.";
+      };
+      params = mkOption {
+        type = types.attrsOf types.str;
+        default = { };
+        description = "Query parameters (values are strings; use \"true\"/\"false\" for bools).";
+      };
+    };
+  };
 in
 {
   options.nixfleet.synology = {
@@ -144,6 +169,27 @@ in
       type = types.listOf nfsExportType;
       default = [ ];
       description = "Declared NFS exports (e.g. the k0s/backup share).";
+    };
+    settings = mkOption {
+      type = types.listOf settingType;
+      default = [ ];
+      example = [
+        {
+          api = "SYNO.Core.FileServ.NFS";
+          method = "set";
+          version = 1;
+          params = {
+            enable_nfs = "true";
+            enable_nfs_v4 = "true";
+          };
+        }
+      ];
+      description = ''
+        Generic DSM API settings calls — the escape hatch for configuring any
+        SYNO.Core.* setting not yet covered by a typed option. The whole DSM
+        settings surface (FileServ.NFS/SMB, Network, System, Service, SNMP, …)
+        uses the same entry.cgi get/set shape. Applied idempotently on --apply.
+      '';
     };
   };
 }


### PR DESCRIPTION
## Summary

Adds a **Model-B Synology backend** to nixfleet: declarative management of the NAS (znas, 192.168.1.67) over the **DSM Web API** — no SSH/closure. Desired state is declared in Nix under `nixfleet.synology` and reconciled by `nixfleet synology {status,reconcile,get}`.

This first slice covers the resources the k0s CSI driver and backups already depend on: **iSCSI LUNs** and **NFS exports**, plus a **generic settings escape hatch** for the rest of the DSM surface.

## What's included

- **`internal/synology/`** — DSM client (auth, self-signed TLS), iSCSI LUN list/create/grow/delete, NFS rule load/save, generic settings call, and a diff/apply engine (dry-run default; `--prune` and `--allow-resize` gated). Unit-tested pure logic.
- **`modules/nixfleet/synology.nix`** — `nixfleet.synology.{iscsiLuns,nfsExports,settings}` options; `base` enum gains `synology`; flake exposes the `.synology` output.
- **`hosts/znas.nix`** + `nixfleetConfigurations.znas`.
- **CLI** (`synology_cmd.go`) — `status`, `reconcile`, generic `get`. Password sourced via `--password-command`/`$SYNOLOGY_PASSWORD` (never in Nix).

## Reverse-engineered (live, against .67)

- iSCSI: `SYNO.Core.ISCSI.LUN` list field is `luns`; create type THIN→`BLUN` (btrfs).
- **Per-share NFS rules**: `SYNO.Core.FileServ.NFS.SharePrivilege` — GET `load` (`share_name`+`clear=false`), SET **`save`** (`+rule=JSON`). Rule schema: `client/privilege/root_squash/async/insecure/crossmnt/security_flavor`. No-op round-trip verified safe.
- Generic settings: the whole `SYNO.Core.*` surface uses one uniform `get`/`set` shape.

## Verified

\`\`\`
status:            k0s-gti  /volume1  NFS: *(rw)
reconcile:         (no changes — NAS matches declared state)   # idempotent
reconcile --apply: clean no-op
get … FileServ.NFS get: live global NFS config
go test ./internal/synology/: PASS (5 tests)
\`\`\`

## Notes / safety

- **Never `--prune` this NAS** — synology-csi creates/deletes LUNs dynamically; nixfleet only declares static resources.
- NFS apply uses the verified `save` path; reconcile only writes on drift.
- **Security follow-up**: k0s-gti export is `client: "*"` — tighten to the real node→.67 subnet once mount source IPs are confirmed (tracked in `znas.nix`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)