### PR TITLE
installer: bump Ubuntu LTS to 24.04.4 (overridable)

### DIFF
--- a/installer/installer-setup.sh
+++ b/installer/installer-setup.sh
@@ -10,7 +10,10 @@
 
 set -euo pipefail
 
-UBUNTU_VERSION="24.04.2"
+# Ubuntu 24.04 LTS (Noble) point release. Override with UBUNTU_VERSION=24.04.x
+# (the fleet installs the LTS; nodes are NOT reinstalled to interim releases —
+# 26.04 was an in-place do-release-upgrade, see osupdate/release.go).
+UBUNTU_VERSION="${UBUNTU_VERSION:-24.04.4}"
 ISO_URL="${ISO_URL:-https://releases.ubuntu.com/${UBUNTU_VERSION}/ubuntu-${UBUNTU_VERSION}-live-server-amd64.iso}"
 DEST="${DEST:-/srv/installer/boot}"
 ISO_CACHE="/var/cache/nixfleet"


### PR DESCRIPTION
Bumps the PXE/autoinstall pinned point release **24.04.2 → 24.04.4** (latest, Feb 2026) and makes it `UBUNTU_VERSION`-overridable.

Context: a fleet-rollback to 24.04 was evaluated but **isn't a downgrade** — node roots are ext4/LVM with no pre-upgrade snapshots, so 26.04→24.04 would require a full reinstall per node. Decision: **keep running nodes on 26.04** (stable after the Cilium 1.19.5 fix) and keep the installer on the LTS so any future fresh install or node replacement lands on 24.04.4.

The autoinstall config itself is release-agnostic (the ISO sets the release); only `installer-setup.sh` pinned the version. `bash -n` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)