### PR TITLE
feat(pki): pathlen:2 root + configurable intermediate pathlen for SPIRE

### DIFF
--- a/cmd/nixfleet/internal/pki/ca.go
+++ b/cmd/nixfleet/internal/pki/ca.go
@@ -39,6 +39,10 @@ type IntermediateCAConfig struct {
 	CommonName   string
 	Organization string
 	Validity     time.Duration
+	// MaxPathLen: 0 (default) = leaf-only intermediate (gateway/TLS certs).
+	// Set 1 for an intermediate that must itself sign a CA (e.g. a SPIRE
+	// upstream, where SPIRE mints its own server CA beneath it).
+	MaxPathLen int
 }
 
 // DefaultIntermediateCAConfig returns sensible defaults for an intermediate CA
@@ -93,8 +97,11 @@ func InitCA(cfg *CAConfig) (*CA, error) {
 		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageCRLSign | x509.KeyUsageDigitalSignature,
 		BasicConstraintsValid: true,
 		IsCA:                  true,
-		MaxPathLen:            1,
-		MaxPathLenZero:        false,
+		// pathlen:2 so the chain root -> intermediate -> SPIRE upstream CA ->
+		// SPIRE server CA -> SVID validates (SPIRE mints its own CA under the
+		// intermediate, which pathlen:1 forbade). Leaf-only intermediates stay 0.
+		MaxPathLen:     2,
+		MaxPathLenZero: false,
 	}
 
 	// Self-sign the CA certificate
@@ -200,8 +207,8 @@ func (ca *CA) InitIntermediateCA(cfg *IntermediateCAConfig) (*IntermediateCA, er
 		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageCRLSign | x509.KeyUsageDigitalSignature,
 		BasicConstraintsValid: true,
 		IsCA:                  true,
-		MaxPathLen:            0,    // Can only sign end-entity certs
-		MaxPathLenZero:        true, // MaxPathLen=0 is intentional
+		MaxPathLen:            cfg.MaxPathLen,
+		MaxPathLenZero:        cfg.MaxPathLen == 0, // pathlen:0 = leaf-only
 	}
 
 	// Sign with root CA

--- a/cmd/nixfleet/internal/pki/pathlen_test.go
+++ b/cmd/nixfleet/internal/pki/pathlen_test.go
@@ -1,0 +1,91 @@
+package pki
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"math/big"
+	"testing"
+	"time"
+)
+
+// signChild issues a cert (CA or leaf) signed by parent, for simulating the
+// part of the chain SPIRE mints itself (its own server CA, then SVIDs).
+func signChild(t *testing.T, cn string, isCA bool, pathlen int, parent *x509.Certificate, parentKey *ecdsa.PrivateKey) (*x509.Certificate, *ecdsa.PrivateKey) {
+	t.Helper()
+	k, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	tmpl := &x509.Certificate{
+		SerialNumber:          big.NewInt(time.Now().UnixNano()),
+		Subject:               pkix.Name{CommonName: cn},
+		NotBefore:             time.Now(),
+		NotAfter:              time.Now().Add(time.Hour),
+		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageDigitalSignature,
+		BasicConstraintsValid: true,
+		IsCA:                  isCA,
+		MaxPathLen:            pathlen,
+		MaxPathLenZero:        isCA && pathlen == 0,
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, parent, &k.PublicKey, parentKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+	c, err := x509.ParseCertificate(der)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return c, k
+}
+
+// TestFleetCAPathlenSupportsSPIRE proves the pathlen:2 root lets a SPIRE
+// upstream intermediate (pathlen:1) parent SPIRE's own CA down to a leaf SVID.
+// This is the exact chain that failed ("too many intermediates for path length
+// constraint") when the root was pathlen:1 / intermediate pathlen:0.
+func TestFleetCAPathlenSupportsSPIRE(t *testing.T) {
+	root, err := InitCA(&CAConfig{CommonName: "Test Root", Organization: "T", Validity: 720 * time.Hour})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if root.Certificate.MaxPathLen != 2 {
+		t.Fatalf("root MaxPathLen = %d, want 2", root.Certificate.MaxPathLen)
+	}
+
+	spireInt, err := root.InitIntermediateCA(&IntermediateCAConfig{
+		CommonName: "SPIRE Upstream", Organization: "T", Validity: time.Hour, MaxPathLen: 1,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if spireInt.Certificate.MaxPathLen != 1 {
+		t.Fatalf("SPIRE intermediate MaxPathLen = %d, want 1", spireInt.Certificate.MaxPathLen)
+	}
+
+	// SPIRE mints its own server CA under the upstream, then a leaf SVID.
+	spireCA, spireCAKey := signChild(t, "SPIRE Server CA", true, 0, spireInt.Certificate, spireInt.PrivateKey)
+	leaf, _ := signChild(t, "workload-svid", false, 0, spireCA, spireCAKey)
+
+	roots := x509.NewCertPool()
+	roots.AddCert(root.Certificate)
+	inter := x509.NewCertPool()
+	inter.AddCert(spireInt.Certificate)
+	inter.AddCert(spireCA)
+	if _, err := leaf.Verify(x509.VerifyOptions{
+		Roots: roots, Intermediates: inter,
+		KeyUsages: []x509.ExtKeyUsage{x509.ExtKeyUsageAny},
+	}); err != nil {
+		t.Fatalf("2-intermediate SPIRE chain must validate under pathlen:2 root: %v", err)
+	}
+
+	// Default intermediate stays leaf-only (pathlen:0) so gateway certs are unaffected.
+	gwInt, err := root.InitIntermediateCA(DefaultIntermediateCAConfig())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if gwInt.Certificate.MaxPathLen != 0 || !gwInt.Certificate.MaxPathLenZero {
+		t.Fatalf("default intermediate must stay pathlen:0, got %d", gwInt.Certificate.MaxPathLen)
+	}
+}


### PR DESCRIPTION
## Why
The Fleet CA hierarchy was leaf-only (root `pathlen:1`, intermediate `pathlen:0`), so SPIRE could not use a Fleet intermediate as `UpstreamAuthority` — SPIRE mints its own CA beneath the upstream, which `pathlen:0` forbids:

```
X509 CA minted by upstream authority is invalid: too many intermediates for path length constraint
```

This crash-looped the SPIRE server on rollout.

## What
- Root `MaxPathLen 1 → 2` so `root → intermediate → SPIRE CA → SVID` validates.
- Add `IntermediateCAConfig.MaxPathLen` (default `0` = leaf-only, unchanged for gateway/TLS certs); set `1` for a SPIRE upstream intermediate.
- Test builds the exact previously-failing chain and verifies it.

## Verified
- `go test ./internal/pki/` green.
- Rotated the live Fleet CA to a `pathlen:2` root; SPIRE now runs rooted in the Fleet CA (`self_signed=false`, bundle anchor = Stigen AI Fleet Root CA); gateway `*.stigen.home` leaf re-issued and validates against the new root.