### PR TITLE
fix(gtr-153): qwopus reasoning-budget 2048->512

### DIFF
--- a/hosts/gtr-153.nix
+++ b/hosts/gtr-153.nix
@@ -61,7 +61,10 @@
         jinja = true;
         reasoning = {
           format = "deepseek";
-          budget = 2048;
+          # 512 (was 2048): 2048 thinking tokens at ~25 tok/s made every turn
+          # ~80s+, blowing agent-chain timeouts. 512 keeps qwopus usable
+          # interactively.
+          budget = 512;
         };
         # Sampler nudge — see hosts/gtr-152.nix / docs/llm-proxy-usage.md.
         # mmproj for vision available at


### PR DESCRIPTION
## What

Lowers the qwopus (`services.qwopus35-coder`) reasoning budget from **2048 → 512** tokens in `hosts/gtr-153.nix`.

## Why

2048 thinking tokens at ~25 tok/s made every qwopus turn ~80s+, which blew timeouts in the agent chain (OpenClaw → LAP → litellm) and surfaced as failures/hangs. 512 keeps qwopus usable interactively while retaining a reasoning budget.

## Notes

- The live host (gtr-153) already runs `512` from an imperative fix, so this just persists it — **no runtime change on merge/deploy**, it prevents a future deploy from reverting to 2048.
- Direct qwopus completion after the change: ~4.5s (was empty/>60s at low max_tokens).