### PR TITLE
iscsi: configurable replacement_timeout, raise to 600s on gti

### DIFF
--- a/hosts/gti.nix
+++ b/hosts/gti.nix
@@ -40,6 +40,13 @@
     # iSCSI initiator so the Synology CSI driver can attach btrfs-backed LUNs.
     modules.iscsi.enable = true;
 
+    # Raise iSCSI session-recovery timeout well above the observed worst-case
+    # Synology DSM stall (~292s on 2026-07-23) so a transient target hiccup makes
+    # I/O hang-and-resume instead of escalating to btrfs forced-readonly on the
+    # gastown LUNs. Single-path single-node: fast failover buys nothing here.
+    # See nix-fleet-hosts-k3x. Takes effect on next iSCSI login (pod roll/reboot).
+    modules.iscsi.replacementTimeout = 600;
+
     # nix-config module is for Determinate-Nix hosts (writes nix.custom.conf).
     # gti runs vanilla nix (require-sigs=false, connects as the trusted ztaylor
     # user, nix config in nix.conf.d/99-nixfleet-optimized.conf) — it has no

--- a/modules/iscsi.nix
+++ b/modules/iscsi.nix
@@ -30,6 +30,22 @@ in
 {
   options.nixfleet.modules.iscsi = {
     enable = lib.mkEnableOption "iSCSI initiator (open-iscsi) for CSI-attached volumes";
+
+    replacementTimeout = lib.mkOption {
+      type = lib.types.ints.positive;
+      default = 120;
+      description = ''
+        iSCSI node.session.timeo.replacement_timeout in seconds — how long the
+        initiator waits for a stalled target before failing in-flight I/O. On
+        single-path nodes raise this above the expected worst-case target stall
+        so a transient Synology DSM hiccup makes I/O hang-and-resume instead of
+        escalating to SCSI-offline → btrfs forced-readonly (the 2026-07-23
+        gastown outage, nix-fleet-hosts-k3x). Applied to iscsid.conf and to
+        existing node records on activation; it takes effect on the next session
+        login/reboot — activation deliberately does NOT force a re-login, which
+        would drop live CSI PVCs. Default 120 preserves upstream behaviour.
+      '';
+    };
   };
 
   config = lib.mkIf cfg.enable {
@@ -81,6 +97,31 @@ in
       systemctl enable --now iscsid.service 2>/dev/null || true
       systemctl enable --now open-iscsi.service 2>/dev/null || true
       echo "iscsi: iscsid is $(systemctl is-active iscsid.service 2>/dev/null)"
+
+      # --- session recovery timeout (NixFleet iscsi module) ---
+      # replacement_timeout bounds how long the initiator waits for a stalled
+      # target before failing I/O. The 120s default let a ~292s Synology DSM
+      # stall on 2026-07-23 escalate to SCSI-offline → btrfs forced-readonly on
+      # the gastown LUNs (nix-fleet-hosts-k3x). A larger value makes I/O hang and
+      # resume when the target returns rather than erroring the filesystem RO.
+      RT=${toString cfg.replacementTimeout}
+      conf=/etc/iscsi/iscsid.conf
+      if [ -f "$conf" ]; then
+        if grep -qE '^[#[:space:]]*node\.session\.timeo\.replacement_timeout' "$conf"; then
+          sed -i -E "s|^[#[:space:]]*node\.session\.timeo\.replacement_timeout.*|node.session.timeo.replacement_timeout = $RT|" "$conf"
+        else
+          printf 'node.session.timeo.replacement_timeout = %s\n' "$RT" >> "$conf"
+        fi
+        echo "iscsi: iscsid.conf replacement_timeout=$RT (new sessions)"
+      fi
+      # Update existing node records so the value takes effect on next login.
+      # Deliberately NOT re-logging-in here — that would drop live CSI PVCs; the
+      # value activates on the next session (re)establishment (pod roll / reboot).
+      if command -v iscsiadm >/dev/null 2>&1; then
+        iscsiadm -m node -o update -n node.session.timeo.replacement_timeout -v "$RT" 2>/dev/null \
+          && echo "iscsi: node records replacement_timeout=$RT (active on next login/reboot)" \
+          || true
+      fi
     '';
 
     nixfleet.healthChecks.iscsid = {


### PR DESCRIPTION
## Why

The `120s` default `node.session.timeo.replacement_timeout` let a **~292s Synology DSM stall on 2026-07-23** escalate to SCSI-offline → **btrfs forced-readonly on both gastown iSCSI LUNs** (`/data` + `/home/agent`), taking the ops loop hard-down. The stall self-healed in ~292s but the pod stayed RO until a **manual roll ~4h later** (btrfs does not auto-clear forced-RO; only a pod delete → CSI unstage/restage clears it).

**Proven proximate chain** (kernel/iscsid logs): both sessions to target `192.168.1.67` missed NOP keepalives at 08:31:17 UTC → 120s replacement_timeout expired at 08:33:18 → devices offline → EIO on in-flight writes → btrfs transaction-abort → forced-RO on both filesystems the same second.

Raising `replacement_timeout` well above the worst-case stall is the **trigger-agnostic fix**: I/O *hangs and resumes* when the target returns instead of erroring the filesystem read-only. On a single-path single-node setup fast failover buys nothing, so a large value is the right trade.

## What

- **`modules/iscsi.nix`**: new `nixfleet.modules.iscsi.replacementTimeout` option (**default `120` — fleet-wide behaviour unchanged**). On activation it enforces the value in `iscsid.conf` *and* updates existing node records. It deliberately does **not** force a re-login — that would drop live CSI PVCs.
- **`hosts/gti.nix`**: sets `replacementTimeout = 600` (only gti).

## Rollout note

Takes effect on the **next iSCSI login** — after this deploys, a controlled `gastown-town-0` pod roll or a gti reboot is needed to activate `600s` on the *current* sessions.

## Refs

- `nix-fleet-hosts-k3x` (this fix)
- Related follow-ups: `nix-fleet-hosts-4qa` (alert on forced-RO/NOP-timeout + auto-delete pod on RO volumes), `nix-fleet-hosts-6cc` (human DSM-side root-cause of the stall trigger; city-volumesnapshot cronjob stays suspended until resolved)
